### PR TITLE
예외 공통 처리 및 에러 코드 작성

### DIFF
--- a/src/main/java/com/api/farmingsoon/common/exception/CustomException.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/CustomException.java
@@ -1,0 +1,14 @@
+package com.api.farmingsoon.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
@@ -10,19 +10,12 @@ public enum ErrorCode {
     EMPTY_REFRESH_TOKEN("RefreshToken이 필요합니다.", HttpStatus.BAD_REQUEST),
     EMPTY_EMAIL("이메일이 필요합니다.", HttpStatus.BAD_REQUEST),
     INVALID_IMAGE_TYPE("유효하지 않은 파일 형식입니다.", HttpStatus.BAD_REQUEST),
-    AWS_FAIL_UPLOAD("AWS S3 업로드 실패!", HttpStatus.CONFLICT),
-
-    NOT_MATCH_EMAIL_TOKEN("이메일 인증 토큰이 일치하지 않습니다.", HttpStatus.CONFLICT),
-    EXPIRED_EMAIL_TOKEN("이메일 인증 토큰을 찾을 수 없습니다.(expired)", HttpStatus.NOT_FOUND),
-    OVER_COUNT_TAGS("관심 태그 개수는 최대 5개까지만 설정이 가능합니다.", HttpStatus.CONFLICT),
 
     // 401
     LOGOUTED_TOKEN("이미 로그아웃 처리된 토큰입니다.", HttpStatus.UNAUTHORIZED),
-    SNATCH_TOKEN("Refresh Token 탈취를 감지하여 로그아웃 처리됩니다.", HttpStatus.UNAUTHORIZED),
-    INVALID_TYPE_TOKEN("Token의 타입은 Bearer입니다.", HttpStatus.UNAUTHORIZED),
     EXPIRED_PERIOD_ACCESS_TOKEN("기한이 만료된 AccessToken입니다.", HttpStatus.UNAUTHORIZED),
     EXPIRED_PERIOD_REFRESH_TOKEN("기한이 만료된 RefreshToken입니다.", HttpStatus.UNAUTHORIZED),
-    EMPTY_AUTHORITY("권한 정보가 필요합니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_TYPE_TOKEN("Token의 타입은 Bearer입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_ACCESS_TOKEN("유효하지 않은 AccessToken입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_REFRESH_TOKEN("유효하지 않은 RefreshToken입니다.", HttpStatus.UNAUTHORIZED),
     INVALID_CURRENT_PASSWORD("현재 비밀번호가 일치하지 않습니다!", HttpStatus.UNAUTHORIZED),
@@ -36,21 +29,10 @@ public enum ErrorCode {
     // 404
     NOT_FOUND_MEMBER("회원이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     NOT_FOUND_ITEM("상품이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
-    NOT_FOUND_PROVIDER("지원하지 않는 소셜 로그인 플랫폼 입니다.", HttpStatus.NOT_FOUND),
-    NOT_FOUND_EMAIL_TOKEN("이메일 인증 토큰이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_BID("입찰이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_NOTIFICATION("알림이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_PROVIDER("지원하지 않는 소셜 로그인 플랫폼 입니다.", HttpStatus.NOT_FOUND);
 
-    ALREADY_JOINED("이미 존재하는 회원입니다.", HttpStatus.CONFLICT),
-
-    // 게시판 관련
-    BAD_REQUEST("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
-    UNAUTHORIZED("로그인해 주세요.", HttpStatus.UNAUTHORIZED),
-    FORBIDDEN("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
-    ITEM_NOT_FOUND("존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND),
-    INTEREST_ARTICLE_ALREADY_EXISTS("이미 좋아한 게시글입니다.", HttpStatus.BAD_REQUEST),
-    UPLOAD_FAILED("파일 업로드에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-
-    // 알림
-    NOTIFICATION_NOT_FOUND("존재하지 않는 알림입니다.", HttpStatus.NOT_FOUND);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
@@ -1,0 +1,62 @@
+package com.api.farmingsoon.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    // 400
+    EMPTY_REFRESH_TOKEN("RefreshToken이 필요합니다.", HttpStatus.BAD_REQUEST),
+    EMPTY_EMAIL("이메일이 필요합니다.", HttpStatus.BAD_REQUEST),
+    INVALID_IMAGE_TYPE("유효하지 않은 파일 형식입니다.", HttpStatus.BAD_REQUEST),
+    AWS_FAIL_UPLOAD("AWS S3 업로드 실패!", HttpStatus.CONFLICT),
+
+    NOT_MATCH_EMAIL_TOKEN("이메일 인증 토큰이 일치하지 않습니다.", HttpStatus.CONFLICT),
+    EXPIRED_EMAIL_TOKEN("이메일 인증 토큰을 찾을 수 없습니다.(expired)", HttpStatus.NOT_FOUND),
+    OVER_COUNT_TAGS("관심 태그 개수는 최대 5개까지만 설정이 가능합니다.", HttpStatus.CONFLICT),
+
+    // 401
+    LOGOUTED_TOKEN("이미 로그아웃 처리된 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    SNATCH_TOKEN("Refresh Token 탈취를 감지하여 로그아웃 처리됩니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_TYPE_TOKEN("Token의 타입은 Bearer입니다.", HttpStatus.UNAUTHORIZED),
+    EXPIRED_PERIOD_ACCESS_TOKEN("기한이 만료된 AccessToken입니다.", HttpStatus.UNAUTHORIZED),
+    EXPIRED_PERIOD_REFRESH_TOKEN("기한이 만료된 RefreshToken입니다.", HttpStatus.UNAUTHORIZED),
+    EMPTY_AUTHORITY("권한 정보가 필요합니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_ACCESS_TOKEN("유효하지 않은 AccessToken입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_REFRESH_TOKEN("유효하지 않은 RefreshToken입니다.", HttpStatus.UNAUTHORIZED),
+    INVALID_CURRENT_PASSWORD("현재 비밀번호가 일치하지 않습니다!", HttpStatus.UNAUTHORIZED),
+    INVALID_NEW_PASSWORD("새 비밀번호가 일치하지 않습니다!", HttpStatus.UNAUTHORIZED),
+
+    // 403
+    FORBIDDEN_CREATE("생성 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    FORBIDDEN_DELETE("삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    FORBIDDEN_UPDATE("수정 권한이 없습니다.", HttpStatus.FORBIDDEN),
+
+    // 404
+    NOT_FOUND_MEMBER("회원이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_ITEM("상품이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_PROVIDER("지원하지 않는 소셜 로그인 플랫폼 입니다.", HttpStatus.NOT_FOUND),
+    NOT_FOUND_EMAIL_TOKEN("이메일 인증 토큰이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+
+    ALREADY_JOINED("이미 존재하는 회원입니다.", HttpStatus.CONFLICT),
+
+    // 게시판 관련
+    BAD_REQUEST("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED("로그인해 주세요.", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    ITEM_NOT_FOUND("존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND),
+    INTEREST_ARTICLE_ALREADY_EXISTS("이미 좋아한 게시글입니다.", HttpStatus.BAD_REQUEST),
+    UPLOAD_FAILED("파일 업로드에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    // 알림
+    NOTIFICATION_NOT_FOUND("존재하지 않는 알림입니다.", HttpStatus.NOT_FOUND);
+
+    private final String message;
+    private final HttpStatus status;
+
+    ErrorCode(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/GlobalExceptionHandler.java
@@ -20,10 +20,10 @@ public class GlobalExceptionHandler {
      * 서비스 로직 도중 발생하는 에러들을 커스텀하여 응답값을 내려줍니다.
      */
     @ExceptionHandler(CustomException.class)
-    public Response<Void> handleCustomException(CustomException e){
+    public ResponseEntity<?> handleCustomException(CustomException e){
         ErrorCode errorCode = e.getErrorCode();
         log.error(errorCode.getMessage());
-        return Response.error(errorCode.getStatus(), errorCode.getMessage());
+        return ResponseEntity.status(errorCode.getStatus()).body(Response.error(errorCode.getStatus(), errorCode.getMessage()));
     }
 
     /**
@@ -31,12 +31,12 @@ public class GlobalExceptionHandler {
      *  itemPrice : 아이템 가격을 100원 이상 1,000,000,000원 이하여야 합니다.
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public Response<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex){
+    public ResponseEntity<?> handleValidationExceptions(MethodArgumentNotValidException ex){
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getAllErrors()
                 .forEach(c -> errors.put(((FieldError) c).getField(), c.getDefaultMessage()));
         log.error(ex.getMessage());
-        return Response.error(HttpStatus.BAD_REQUEST, errors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Response.error(HttpStatus.BAD_REQUEST, errors));
     }
 
 }

--- a/src/main/java/com/api/farmingsoon/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.api.farmingsoon.common.exception;
+
+import com.api.farmingsoon.common.response.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * 서비스 로직 도중 발생하는 에러들을 커스텀하여 응답값을 내려줍니다.
+     */
+    @ExceptionHandler(CustomException.class)
+    public Response<Void> handleCustomException(CustomException e){
+        ErrorCode errorCode = e.getErrorCode();
+        log.error(errorCode.getMessage());
+        return Response.error(errorCode.getStatus(), errorCode.getMessage());
+    }
+
+    /**
+     * 바인딩 에러 json형식으로 에러가 있는 파라미터 값에 메시지를 담아 넘겨줍니다.
+     *  itemPrice : 아이템 가격을 100원 이상 1,000,000,000원 이하여야 합니다.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public Response<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex){
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors()
+                .forEach(c -> errors.put(((FieldError) c).getField(), c.getDefaultMessage()));
+        log.error(ex.getMessage());
+        return Response.error(HttpStatus.BAD_REQUEST, errors);
+    }
+
+}

--- a/src/main/java/com/api/farmingsoon/common/exception/custom_exception/AwsS3Exception.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/custom_exception/AwsS3Exception.java
@@ -1,0 +1,11 @@
+package com.api.farmingsoon.common.exception.custom_exception;
+
+
+import com.api.farmingsoon.common.exception.CustomException;
+import com.api.farmingsoon.common.exception.ErrorCode;
+
+public class AwsS3Exception extends CustomException {
+    public AwsS3Exception(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/exception/custom_exception/BadRequestException.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/custom_exception/BadRequestException.java
@@ -1,0 +1,11 @@
+package com.api.farmingsoon.common.exception.custom_exception;
+
+
+import com.api.farmingsoon.common.exception.CustomException;
+import com.api.farmingsoon.common.exception.ErrorCode;
+
+public class BadRequestException extends CustomException {
+    public BadRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/exception/custom_exception/DuplicateException.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/custom_exception/DuplicateException.java
@@ -1,0 +1,10 @@
+package com.api.farmingsoon.common.exception.custom_exception;
+
+import com.api.farmingsoon.common.exception.CustomException;
+import com.api.farmingsoon.common.exception.ErrorCode;
+
+public class DuplicateException extends CustomException {
+    public DuplicateException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/exception/custom_exception/ForbiddenException.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/custom_exception/ForbiddenException.java
@@ -1,0 +1,10 @@
+package com.api.farmingsoon.common.exception.custom_exception;
+
+import com.api.farmingsoon.common.exception.CustomException;
+import com.api.farmingsoon.common.exception.ErrorCode;
+
+public class ForbiddenException extends CustomException {
+    public ForbiddenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/exception/custom_exception/InvalidException.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/custom_exception/InvalidException.java
@@ -1,0 +1,10 @@
+package com.api.farmingsoon.common.exception.custom_exception;
+
+import com.api.farmingsoon.common.exception.CustomException;
+import com.api.farmingsoon.common.exception.ErrorCode;
+
+public class InvalidException extends CustomException {
+    public InvalidException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/exception/custom_exception/NotFoundException.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/custom_exception/NotFoundException.java
@@ -1,0 +1,10 @@
+package com.api.farmingsoon.common.exception.custom_exception;
+
+import com.api.farmingsoon.common.exception.CustomException;
+import com.api.farmingsoon.common.exception.ErrorCode;
+
+public class NotFoundException extends CustomException {
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/exception/custom_exception/NotMatchException.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/custom_exception/NotMatchException.java
@@ -1,0 +1,10 @@
+package com.api.farmingsoon.common.exception.custom_exception;
+
+import com.api.farmingsoon.common.exception.CustomException;
+import com.api.farmingsoon.common.exception.ErrorCode;
+
+public class NotMatchException extends CustomException {
+    public NotMatchException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/response/Response.java
+++ b/src/main/java/com/api/farmingsoon/common/response/Response.java
@@ -23,4 +23,8 @@ public class Response<T> {
     public static Response<Void> error(HttpStatus status, String message) {
         return new Response<>(status.value(), message, null);
     }
+
+    public static <T> Response<T> error(HttpStatus status, T result) {
+        return new Response<>(status.value(), null, result);
+    }
 }


### PR DESCRIPTION
## 💡 관련 이슈

> this closed #2 예외 공통 처리 및 에러 코드 작성

## ✅ 작업 상세 내용

- 예외 공통 처리를 위한 GlobalExceptionHandler를 생성했습니다.
- 바인딩 에러를 처리하기 위해 Response<T> error(HttpStatus status, T result) 메서드를 추가했습니다.


## ⭐ 특이사항
- Error Code는 일단 이전 프로젝트 그대로 가져왔고 상태 코드에 따라 관리할 것인지 도메인에 따라 관리할 것인지에 따라 정리하고 커밋하겠습니다. 

```
    NOT_FOUND_ITEM("상품이 존재하지 않습니다.", HttpStatus.NOT_FOUND)
    ITEM_NOT_FOUND("존재하지 않는 게시글입니다.", HttpStatus.NOT_FOUND)

    FORBIDDEN_CREATE("생성 권한이 없습니다.", HttpStatus.FORBIDDEN)
    FORBIDDEN("접근 권한이 없습니다.", HttpStatus.FORBIDDEN)

```
이런거 중복없이 하나로 가져가고 포맷도 통일하면 좋을거같습니다~

## 📃 참고할만한 자료
