### PR TITLE
회원가입 및 로그인 기능 구현1(JWT)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// jwt
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
@@ -35,6 +43,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     FORBIDDEN_CREATE("생성 권한이 없습니다.", HttpStatus.FORBIDDEN),
     FORBIDDEN_DELETE("삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
     FORBIDDEN_UPDATE("수정 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    EMPTY_AUTHORITY("권한 정보가 비어있습니다.", HttpStatus.FORBIDDEN),
 
     // 404
     NOT_FOUND_MEMBER("회원이 존재하지 않습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/api/farmingsoon/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/api/farmingsoon/common/interceptor/AuthenticationInterceptor.java
@@ -1,0 +1,37 @@
+package com.api.farmingsoon.common.interceptor;
+
+import com.api.farmingsoon.common.security.jwt.JwtProvider;
+import com.api.farmingsoon.common.util.JwtUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private final JwtProvider jwtProvider;
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        log.info("Authentication Interceptor : " + request.getRequestURI());
+        String accessToken = JwtUtils.extractBearerToken(request.getHeader(HttpHeaders.AUTHORIZATION));
+
+        if (!request.getRequestURI().equals("/api/auth/member/rotate")&& !request.getRequestURI().equals("/api/auth/member/logout") && accessToken != null) { // 토큰 재발급의 요청이 아니면서 accessToken이 존재할 때
+
+            if (jwtProvider.validateAccessToken(accessToken)) { // 토큰이 유효한 경우 and 로그인 상태
+                Authentication authentication = jwtProvider.getAuthenticationByAccessToken(accessToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/redis/RedisConfig.java
+++ b/src/main/java/com/api/farmingsoon/common/redis/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.api.farmingsoon.common.redis;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(redisHost);
+        config.setPort(redisPort);
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericToStringSerializer<Long>(Long.class));
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/redis/RedisService.java
+++ b/src/main/java/com/api/farmingsoon/common/redis/RedisService.java
@@ -1,0 +1,43 @@
+package com.api.farmingsoon.common.redis;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Service
+public class RedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @PostConstruct
+    public void initialize() {
+        Set<String> keys = redisTemplate.keys("*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+    public void setData(String key, Object value, Long time,TimeUnit timeUnit) {
+        redisTemplate.opsForValue().set(key, value.toString(), time, timeUnit);
+    }
+
+    public Object getData(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public Set<String> getKeySet(String domain) {
+        return redisTemplate.keys(domain);
+    }
+
+    public void deleteData(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public void increaseData(String key) {
+        redisTemplate.opsForValue().increment(key);
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/api/farmingsoon/common/security/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.api.farmingsoon.common.security;
+package com.api.farmingsoon.common.security.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/api/farmingsoon/common/security/jwt/JwtProvider.java
+++ b/src/main/java/com/api/farmingsoon/common/security/jwt/JwtProvider.java
@@ -1,0 +1,168 @@
+package com.api.farmingsoon.common.security.jwt;
+
+import com.api.farmingsoon.common.exception.ErrorCode;
+import com.api.farmingsoon.common.exception.custom_exception.InvalidException;
+import com.api.farmingsoon.common.util.JwtUtils;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtProvider {
+
+
+    @Value("${custom.jwt.token.access-expiration-time}")
+    private long accessExpirationTime;
+
+    @Value("${custom.jwt.token.refresh-expiration-time}")
+    private long refreshExpirationTime;
+
+    private final JwtUtils jwtUtils;
+
+    private final Key key;
+
+    @Autowired
+    public JwtProvider(@Value("${custom.jwt.secret}") String secretKey, JwtUtils jwtUtils) {
+        this.jwtUtils = jwtUtils;
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /**
+     * @Description
+     * 토큰 발급 및 재발급 시 동작
+     */
+    public JwtTokenRes createJwtToken(String username, String authorities) {
+
+        Date now = new Date();
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put("roles", authorities);
+
+        String accessToken = createAccessToken(claims, new Date(now.getTime() + accessExpirationTime));
+        String refreshToken = createRefreshToken(claims, new Date(now.getTime() + refreshExpirationTime));
+
+        return new JwtTokenRes("Bearer", accessToken, refreshToken);
+    }
+
+    public String createAccessToken(Claims claims, Date expiredDate){
+        return  Jwts.builder()
+                .setClaims(claims) // 아이디, 권한정보
+                .setExpiration(expiredDate) // 만료기간
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(Claims claims, Date expiredDate){
+        String refreshToken = Jwts.builder()
+                .setClaims(claims) // 아이디, 권한정보
+                .setExpiration(expiredDate) // 만료기간
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+        jwtUtils.setRefreshToken(claims.getSubject(), refreshToken);
+        return  refreshToken;
+    }
+
+    public Authentication getAuthenticationByAccessToken(String accessToken){
+        Claims claims = parseAccessTokenClaims(accessToken);
+
+        if (claims.get("roles") == null){
+            throw new InvalidException(ErrorCode.EMPTY_AUTHORITY);
+        }
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("roles").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    public Claims parseAccessTokenClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        }
+        catch (ExpiredJwtException e) {
+            throw new InvalidException(ErrorCode.EXPIRED_PERIOD_ACCESS_TOKEN);
+        } catch (final JwtException | IllegalArgumentException e) {
+            throw new InvalidException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
+
+    public Authentication getAuthenticationByRefreshToken(String refreshToken){
+        Claims claims = parseRefreshTokenClaims(refreshToken);
+
+        if (claims.get("roles") == null){
+            throw new InvalidException(ErrorCode.EMPTY_AUTHORITY);
+        }
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("roles").toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    public Claims parseRefreshTokenClaims(String refreshToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(refreshToken).getBody();
+        }
+        catch (ExpiredJwtException e) {
+            throw new InvalidException(ErrorCode.EXPIRED_PERIOD_REFRESH_TOKEN);
+        } catch (final JwtException | IllegalArgumentException e) {
+            throw new InvalidException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    /**
+     * @Description
+     * 토큰의 만료여부와 유효성에 대해 검증합니다.
+     */
+    public boolean validateAccessToken(String accessToken) {
+        try {
+            parseToken(accessToken);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new InvalidException(ErrorCode.EXPIRED_PERIOD_ACCESS_TOKEN);
+        } catch (final JwtException | IllegalArgumentException e) {
+            throw new InvalidException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
+    public boolean validateRefreshToken(String refreshToken) {
+        try {
+            parseToken(refreshToken);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new InvalidException(ErrorCode.EXPIRED_PERIOD_REFRESH_TOKEN);
+        } catch (final JwtException | IllegalArgumentException e) {
+            throw new InvalidException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    private Jws<Claims> parseToken(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/security/jwt/JwtTokenRes.java
+++ b/src/main/java/com/api/farmingsoon/common/security/jwt/JwtTokenRes.java
@@ -1,0 +1,15 @@
+package com.api.farmingsoon.common.security.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JwtTokenRes {
+
+    private final String tokenType;
+    private final String accessToken;
+    private final String refreshToken;
+
+
+}

--- a/src/main/java/com/api/farmingsoon/common/util/JwtUtils.java
+++ b/src/main/java/com/api/farmingsoon/common/util/JwtUtils.java
@@ -1,0 +1,50 @@
+package com.api.farmingsoon.common.util;
+
+import com.api.farmingsoon.common.exception.ErrorCode;
+import com.api.farmingsoon.common.exception.custom_exception.BadRequestException;
+import com.api.farmingsoon.common.redis.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.TimeUnit;
+@Component
+@RequiredArgsConstructor
+public class JwtUtils {
+
+    private final RedisService redisService;
+
+    @Value("${custom.jwt.token.refresh-expiration-time}")
+    private long refreshExpirationTime;
+    /**
+     * @Description
+     * Bearer토큰의 여부에 대해 검증한 뒤 토큰을 반환합니다.
+     */
+    public static String extractBearerToken(String token) {
+        if (token != null) {
+            if (!token.startsWith("Bearer")) {
+                throw new BadRequestException(ErrorCode.INVALID_TYPE_TOKEN);
+            }
+
+            return token.split(" ")[1].trim();
+        }
+        return null;
+    }
+    public void rotateRefreshToken(String prevRefreshToken, String newRefreshToken, String email) {
+        // 만료: redis 에서 삭제 후 재등록..
+        deleteRefreshToken(prevRefreshToken);
+        setRefreshToken(newRefreshToken, email);
+    }
+
+    public void setRefreshToken(String refreshToken, String email) {
+        redisService.setData(refreshToken, email, refreshExpirationTime, TimeUnit.SECONDS);
+    }
+
+    public void deleteRefreshToken(String refreshToken) {
+        redisService.deleteData(refreshToken);
+    }
+
+    public String getRefreshToken(String refreshToken) {
+        return redisService.getData(refreshToken).toString();
+    }
+
+}

--- a/src/main/java/com/api/farmingsoon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/controller/MemberController.java
@@ -1,25 +1,48 @@
 package com.api.farmingsoon.domain.member.controller;
 
+import com.api.farmingsoon.common.exception.ErrorCode;
+import com.api.farmingsoon.common.exception.custom_exception.BadRequestException;
 import com.api.farmingsoon.common.response.Response;
+import com.api.farmingsoon.common.security.jwt.JwtTokenRes;
+import com.api.farmingsoon.common.util.JwtUtils;
+import com.api.farmingsoon.domain.member.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/members")
+@RequestMapping("/api/auth/members")
+@RequiredArgsConstructor
 public class MemberController {
 
-    @GetMapping("/test")
-    public Response<List<String>> test() {
-        List<String> response = List.of("test1", "test2", "test3");
-        return Response.success(HttpStatus.OK, "테스트 성공!", response);
+    private final MemberService memberService;
+
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/logout")
+    public Response<Void> logoutMember() {
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        memberService.logout(username);
+        return Response.success(HttpStatus.OK, "로그아웃 처리 되었습니다.");
     }
 
-    @GetMapping("/void-test")
-    public Response<Void> voidTest() {
-        return Response.success(HttpStatus.OK, "void 테스트 성공!");
+    @GetMapping("/rotate")
+    public Response<JwtTokenRes> rotateToken(HttpServletRequest request){
+        String refreshToken = JwtUtils.extractBearerToken(request.getHeader("refreshToken"));
+        if(refreshToken.isBlank()) {
+            throw new BadRequestException(ErrorCode.EMPTY_REFRESH_TOKEN);
+        }
+
+        JwtTokenRes jwtTokenRes = memberService.rotateToken(refreshToken);
+
+        return Response.success(HttpStatus.OK, "토큰이 재발급 되었습니다.", jwtTokenRes);
     }
+
 }

--- a/src/main/java/com/api/farmingsoon/domain/member/model/Member.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/model/Member.java
@@ -1,0 +1,27 @@
+package com.api.farmingsoon.domain.member.model;
+
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column
+    private MemberRole role;
+
+    @Builder
+    private Member(String email, MemberRole role) {
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/api/farmingsoon/domain/member/model/MemberRole.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/model/MemberRole.java
@@ -1,0 +1,22 @@
+package com.api.farmingsoon.domain.member.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberRole {
+
+    ADMIN("ROLE_ADMIN"),
+    MANAGER("ROLE_MANAGER");
+
+    private final String value;
+
+    public static MemberRole checkMemberRole(String role) {
+        return switch (role) {
+            case "ADMIN" -> ADMIN;
+            case "MANAGER" -> MANAGER;
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/com/api/farmingsoon/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.api.farmingsoon.domain.member.repository;
+
+import com.api.farmingsoon.domain.member.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/api/farmingsoon/domain/member/service/MemberService.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/service/MemberService.java
@@ -1,0 +1,47 @@
+package com.api.farmingsoon.domain.member.service;
+
+import com.api.farmingsoon.common.security.jwt.JwtProvider;
+import com.api.farmingsoon.common.security.jwt.JwtTokenRes;
+import com.api.farmingsoon.common.util.JwtUtils;
+import com.api.farmingsoon.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final JwtUtils jwtUtils;
+    private final JwtProvider jwtProvider;
+    private final MemberRepository memberRepository;
+
+    /**
+     *  @Description
+     *  토큰 재발급
+     *  1. 토큰 검증 및 인증객체 불러오기
+     *  2. 기존 토큰 만료처리 and 새로운 토큰 재등록
+     *  3. return
+     */
+    public JwtTokenRes rotateToken(String prevRefreshToken) {
+        jwtProvider.validateRefreshToken(prevRefreshToken);
+        Authentication authentication = jwtProvider.getAuthenticationByRefreshToken(prevRefreshToken);
+
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        JwtTokenRes jwtToken = jwtProvider.createJwtToken(authentication.getName(), authorities);
+        jwtUtils.rotateRefreshToken(prevRefreshToken, jwtToken.getRefreshToken(), authentication.getName());
+        return jwtToken;
+    }
+
+    public void logout(String refreshToken) {
+        jwtUtils.deleteRefreshToken(refreshToken);
+    }
+}


### PR DESCRIPTION
## 💡 관련 이슈

- #5 

## ✅ 작업 상세 내용

- **refreshToken 탈취감지 제거 -> 이전 프로젝트와 다르게 사용자 별 토큰을 여러 개 가져가는 방식으로 전환했습니다.**
```
email : token
사용자의 세션은 하나임이 보장됨
침입자가 갱신을 해버렸다.
사용자가 이미 갱신된 토큰으로 접근을하면? -> 둘 다 로그아웃

위 방법 문제점
1. 다른 환경에서 동시 로그인 불가()
2. 웹, 앱 동시 사용 불가
```
- **토큰 재발급 및 로그아웃 기능 구현**
AC는 따로 관리하기 어렵다고 판단해 유효 기간을 짧게 가져가기로 했고 RC를 이용해 재발급 및 로그아웃 기능을 처리했습니다.(재발급 or 로그아웃 시 RT첨부)

- **필터 -> 인터셉터 전환**
필터 단에서 발생하는 예외를 ControllerAdvice로 처리하기 위해 필터에서 진행했던 로직을 인터셉터로 전환했습니다~

## ⭐ 특이사항

## 📃 참고할만한 자료
- https://engineerinsight.tistory.com/232#%E2%9C%94%EF%B8%8F%C2%A0%EB%A1%9C%EA%B7%B8%EC%95%84%EC%9B%83%20%EC%8B%9C%EC%97%90%20%EB%B8%94%EB%9E%99%EB%A6%AC%EC%8A%A4%ED%8A%B8%EC%97%90%20Refresh%20Token%EC%9D%84%20%EC%A0%80%EC%9E%A5%ED%95%9C%EB%8B%A4.-1

This closed #5