### PR TITLE
회원 가입 및 폼 로그인 기능 구현

### DIFF
--- a/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
@@ -32,8 +32,10 @@ public enum ErrorCode {
     NOT_FOUND_ITEM("상품이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     NOT_FOUND_BID("입찰이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     NOT_FOUND_NOTIFICATION("알림이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
-    NOT_FOUND_PROVIDER("지원하지 않는 소셜 로그인 플랫폼 입니다.", HttpStatus.NOT_FOUND);
+    NOT_FOUND_PROVIDER("지원하지 않는 소셜 로그인 플랫폼 입니다.", HttpStatus.NOT_FOUND),
 
+    // 409
+    ALREADY_JOINED("이미 존재하는 회원입니다.", HttpStatus.CONFLICT);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/api/farmingsoon/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/api/farmingsoon/common/interceptor/AuthenticationInterceptor.java
@@ -24,7 +24,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         log.info("Authentication Interceptor : " + request.getRequestURI());
         String accessToken = JwtUtils.extractBearerToken(request.getHeader(HttpHeaders.AUTHORIZATION));
 
-        if (!request.getRequestURI().equals("/api/auth/member/rotate")&& !request.getRequestURI().equals("/api/auth/member/logout") && accessToken != null) { // 토큰 재발급의 요청이 아니면서 accessToken이 존재할 때
+        if (accessToken != null) { // 토큰 재발급의 요청이 아니면서 accessToken이 존재할 때
 
             if (jwtProvider.validateAccessToken(accessToken)) { // 토큰이 유효한 경우 and 로그인 상태
                 Authentication authentication = jwtProvider.getAuthenticationByAccessToken(accessToken);
@@ -34,4 +34,6 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
         return true;
     }
+
+
 }

--- a/src/main/java/com/api/farmingsoon/common/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/api/farmingsoon/common/security/service/CustomUserDetailsService.java
@@ -1,0 +1,44 @@
+package com.api.farmingsoon.common.security.service;
+
+import com.api.farmingsoon.common.exception.custom_exception.NotFoundException;
+import com.api.farmingsoon.domain.member.model.Member;
+import com.api.farmingsoon.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.api.farmingsoon.common.exception.ErrorCode.NOT_FOUND_MEMBER;
+
+@RequiredArgsConstructor
+@Service("userDetailsService")
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * @Description
+     * 폼 로그인 진행시 수행
+     * email을 통해 member를 얻어오고 이를 통해 UserDetails 객체를 만들기만 하면 되기 때문에
+     * 별도로 UserDetails를 구현하는 클래스는 만들지 않았습니다.
+     */
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new NotFoundException(NOT_FOUND_MEMBER));
+
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + member.getRole().name()));
+        return User.builder()
+                .username(member.getEmail())
+                .password(member.getPassword())
+                .authorities(authorities)
+                .build();
+    }
+}

--- a/src/main/java/com/api/farmingsoon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/controller/MemberController.java
@@ -5,23 +5,39 @@ import com.api.farmingsoon.common.exception.custom_exception.BadRequestException
 import com.api.farmingsoon.common.response.Response;
 import com.api.farmingsoon.common.security.jwt.JwtToken;
 import com.api.farmingsoon.common.util.JwtUtils;
+import com.api.farmingsoon.domain.member.dto.JoinRequest;
+import com.api.farmingsoon.domain.member.dto.LoginRequest;
+import com.api.farmingsoon.domain.member.dto.LoginResponse;
 import com.api.farmingsoon.domain.member.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 @RestController
-@RequestMapping("/api/auth/members")
+@RequestMapping("/api/members")
 @RequiredArgsConstructor
 public class MemberController {
 
     private final MemberService memberService;
+
+
+    @PostMapping(value = "/join")
+    public Response<Void> join(@ModelAttribute @Valid JoinRequest joinRequest) throws IOException {
+        memberService.join(joinRequest);
+        return Response.success(HttpStatus.OK, "회원가입이 성공적으로 처리되었습니다.");
+    }
+
+    @PostMapping("/login")
+    public Response<LoginResponse> login(@RequestBody @Valid LoginRequest loginRequest) {
+        LoginResponse loginResponse = memberService.login(loginRequest);
+        return Response.success(HttpStatus.OK, "토큰이 재발급 되었습니다.", loginResponse);
+    }
 
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/logout")

--- a/src/main/java/com/api/farmingsoon/domain/member/dto/JoinRequest.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/dto/JoinRequest.java
@@ -1,0 +1,34 @@
+package com.api.farmingsoon.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@ToString
+public class JoinRequest {
+
+    @NotBlank(message = "이메일은 필수 입력값 입니다.")
+    @Email(message = "이메일 형식에 맞게 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력값 입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 최소 8글자, 최대 20글자로 작성해야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "비밀번호는 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+    private String password;
+
+
+    @NotBlank(message = "닉네임은 필수 입력값 입니다.")
+    @Size(min = 2, max = 20, message = "닉네임은 최소 2글자, 최대 20글자로 작성해야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z가-힣0-9]*$", message = "닉네임은 영문, 한글, 숫자를 사용해서 작성해주세요.")
+    private String nickname;
+
+    private MultipartFile profileImg;
+
+}

--- a/src/main/java/com/api/farmingsoon/domain/member/dto/LoginRequest.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/dto/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.api.farmingsoon.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+
+    @NotBlank(message = "이메일은 필수 입력값 입니다.")
+    @Email(message = "이메일 형식에 맞게 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력값 입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 최소 8글자, 최대 20글자로 작성해야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9]*$", message = "비밀번호는 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+    private String password;
+}

--- a/src/main/java/com/api/farmingsoon/domain/member/dto/LoginResponse.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/dto/LoginResponse.java
@@ -1,0 +1,34 @@
+package com.api.farmingsoon.domain.member.dto;
+
+import com.api.farmingsoon.common.security.jwt.JwtToken;
+import com.api.farmingsoon.domain.member.model.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LoginResponse {
+
+    private final Long memberId;
+    private final String tokenType;
+    private final String accessToken;
+    private final String refreshToken;
+    private final String profileImgUrl;
+
+    @Builder
+    private LoginResponse(String accessToken, String refreshToken, Long memberId, String profileImgUrl){
+        this.memberId = memberId;
+        this.tokenType = "Bearer";
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.profileImgUrl = profileImgUrl;
+    }
+
+    public static LoginResponse of(JwtToken jwtToken, Member member) {
+        return LoginResponse.builder()
+                .memberId(member.getId())
+                .accessToken(jwtToken.getAccessToken())
+                .refreshToken(jwtToken.getRefreshToken())
+                .profileImgUrl(member.getProfileImg())
+                .build();
+    }
+}

--- a/src/main/java/com/api/farmingsoon/domain/member/model/Member.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/model/Member.java
@@ -22,17 +22,21 @@ public class Member {
     @Column(nullable = false)
     private String nickname;
 
+    @Column(nullable = true)
+    private String password;
+
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 
     private String profileImg;
 
     @Builder
-    private Member(String email, MemberRole role, String profileImg, String nickname) {
+    private Member(String email, MemberRole role, String profileImg, String nickname, String password) {
         this.email = email;
         this.role = role;
         this.profileImg = profileImg;
         this.nickname = nickname;
+        this.password = password;
     }
 
     public void updateSocialMember(String email, String nickname, String picture) {


### PR DESCRIPTION
## 💡 관련 이슈

- #9 

## ✅ 작업 상세 내용

- 나머지 api도 개발할까 했는데 이미지 업로드 로직이 아직 도입되지 않아서 일단 보류했습니다.
(회원가입, 로그인만 진행)
- 인증이 필요한 api에 auth를 붙여서 사용하자고 했었는데 restful이 깨지고 필요성을 못 느껴서 제거했습니다.
- interceptor에서 logout, rotate요청만 걸러내는 코드가 있었는데 불필요해 보여서 제거했습니다.

## ⭐ 특이사항

## 📃 참고할만한 자료

This closed #9 