### PR TITLE
로그인 여부 확인 AOP적용 + 권한체킹 공통 처리

### DIFF
--- a/src/main/java/com/api/farmingsoon/common/annotation/LoginChecking.java
+++ b/src/main/java/com/api/farmingsoon/common/annotation/LoginChecking.java
@@ -1,0 +1,11 @@
+package com.api.farmingsoon.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginChecking {
+}

--- a/src/main/java/com/api/farmingsoon/common/aop/LoginCheckingAop.java
+++ b/src/main/java/com/api/farmingsoon/common/aop/LoginCheckingAop.java
@@ -1,0 +1,29 @@
+package com.api.farmingsoon.common.aop;
+
+import com.api.farmingsoon.common.exception.ErrorCode;
+import com.api.farmingsoon.common.exception.custom_exception.ForbiddenException;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class LoginCheckingAop {
+
+    @Pointcut("@annotation(com.api.farmingsoon.common.annotation.LoginChecking)")
+    private void enableLoginChecking(){}
+
+    @Around("enableLoginChecking()")
+    public void around(ProceedingJoinPoint joinPoint) throws Throwable {
+         if(SecurityContextHolder.getContext().getAuthentication().getPrincipal().equals("anonymousUser")) {
+            throw new ForbiddenException(ErrorCode.NOT_LOGIN);
+        }
+        joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     INVALID_NEW_PASSWORD("새 비밀번호가 일치하지 않습니다!", HttpStatus.UNAUTHORIZED),
 
     // 403
+    NOT_LOGIN("로그인 후 이용할 수 있습니다.", HttpStatus.FORBIDDEN),
     FORBIDDEN_CREATE("생성 권한이 없습니다.", HttpStatus.FORBIDDEN),
     FORBIDDEN_DELETE("삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
     FORBIDDEN_UPDATE("수정 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/api/farmingsoon/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/api/farmingsoon/common/security/config/SecurityConfig.java
@@ -24,9 +24,6 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
         return http
-                .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
-                )
                 .csrf(csrf -> csrf.disable())
                 .headers((headers) -> headers
                         .addHeaderWriter(new XFrameOptionsHeaderWriter(

--- a/src/main/java/com/api/farmingsoon/common/security/service/CustomUserDetailsService.java
+++ b/src/main/java/com/api/farmingsoon/common/security/service/CustomUserDetailsService.java
@@ -3,6 +3,7 @@ package com.api.farmingsoon.common.security.service;
 import com.api.farmingsoon.common.exception.custom_exception.NotFoundException;
 import com.api.farmingsoon.domain.member.model.Member;
 import com.api.farmingsoon.domain.member.repository.MemberRepository;
+import com.api.farmingsoon.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.api.farmingsoon.common.exception.ErrorCode.NOT_FOUND_MEMBER;
 
@@ -21,7 +23,7 @@ import static com.api.farmingsoon.common.exception.ErrorCode.NOT_FOUND_MEMBER;
 @Service("userDetailsService")
 public class CustomUserDetailsService implements UserDetailsService {
 
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     /**
      * @Description
@@ -31,8 +33,7 @@ public class CustomUserDetailsService implements UserDetailsService {
      */
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new NotFoundException(NOT_FOUND_MEMBER));
-
+        Member member = memberService.getMemberByEmail(email);
         List<GrantedAuthority> authorities = new ArrayList<>();
         authorities.add(new SimpleGrantedAuthority("ROLE_" + member.getRole().name()));
         return User.builder()

--- a/src/main/java/com/api/farmingsoon/common/util/AuthenticationUtils.java
+++ b/src/main/java/com/api/farmingsoon/common/util/AuthenticationUtils.java
@@ -1,14 +1,38 @@
 package com.api.farmingsoon.common.util;
 
+import com.api.farmingsoon.common.exception.ErrorCode;
+import com.api.farmingsoon.common.exception.custom_exception.ForbiddenException;
+import com.api.farmingsoon.domain.member.model.Member;
+import com.api.farmingsoon.domain.member.model.MemberRole;
+import com.api.farmingsoon.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 
+@RequiredArgsConstructor
+@Component
 public class AuthenticationUtils {
-    public static String getEmail() {
-        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || authentication.getName() == null) {
-            throw new RuntimeException("인증 정보가 없습니다!");
+
+    private final MemberService memberService;
+
+    public static void checkUpdatePermission(Member member) {
+        String authenticationMemberName = SecurityContextHolder.getContext().getAuthentication().getName();
+        if(!authenticationMemberName.equals(member.getEmail()) || !member.getRole().getValue().equals(MemberRole.ADMIN))
+        {
+            throw new ForbiddenException(ErrorCode.FORBIDDEN_UPDATE);
         }
-        return authentication.getName();
     }
+
+    public static void checkDeletePermission(Member member) {
+        String authenticationMemberName = SecurityContextHolder.getContext().getAuthentication().getName();
+        if (!authenticationMemberName.equals(member.getEmail()) || !member.getRole().getValue().equals(MemberRole.ADMIN)) {
+            throw new ForbiddenException(ErrorCode.FORBIDDEN_DELETE);
+        }
+    }
+    public Member getAuthenticationMember()
+    {
+        return memberService.getMemberByEmail(SecurityContextHolder.getContext().getAuthentication().getName());
+    }
+
 }

--- a/src/main/java/com/api/farmingsoon/common/util/JwtUtils.java
+++ b/src/main/java/com/api/farmingsoon/common/util/JwtUtils.java
@@ -3,6 +3,8 @@ package com.api.farmingsoon.common.util;
 import com.api.farmingsoon.common.exception.ErrorCode;
 import com.api.farmingsoon.common.exception.custom_exception.BadRequestException;
 import com.api.farmingsoon.common.redis.RedisService;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -43,8 +45,12 @@ public class JwtUtils {
         redisService.deleteData(refreshToken);
     }
 
-    public String getRefreshToken(String refreshToken) {
-        return redisService.getData(refreshToken).toString();
+    public static String getRefreshToken(HttpServletRequest request) {
+        String refreshToken = extractBearerToken(request.getHeader("refreshToken"));
+        if(refreshToken.isBlank()) {
+            throw new BadRequestException(ErrorCode.EMPTY_REFRESH_TOKEN);
+        }
+        return refreshToken;
     }
 
 }

--- a/src/main/java/com/api/farmingsoon/common/web/WebConfig.java
+++ b/src/main/java/com/api/farmingsoon/common/web/WebConfig.java
@@ -1,0 +1,33 @@
+package com.api.farmingsoon.common.web;
+
+import com.api.farmingsoon.common.interceptor.AuthenticationInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private  final AuthenticationInterceptor authenticationInterceptor;
+    private final List<String> excludePointList = Arrays.asList();
+
+    private final List<String> addEndPointList = Arrays.asList("/api/**");
+
+    /**
+     * @Description
+     * Interceptor 등록
+     */
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authenticationInterceptor)
+                .addPathPatterns(addEndPointList)
+               .excludePathPatterns(excludePointList);
+    }
+}

--- a/src/main/java/com/api/farmingsoon/domain/item/controller/ItemController.java
+++ b/src/main/java/com/api/farmingsoon/domain/item/controller/ItemController.java
@@ -1,6 +1,7 @@
 package com.api.farmingsoon.domain.item.controller;
 
 
+import com.api.farmingsoon.common.annotation.LoginChecking;
 import com.api.farmingsoon.common.response.Response;
 import com.api.farmingsoon.domain.item.dto.ItemCreateRequest;
 import com.api.farmingsoon.domain.item.dto.ItemResponse;
@@ -13,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,6 +25,7 @@ public class ItemController {
 
     private final ItemService itemService;
 
+    @LoginChecking
     @PostMapping
     public Response<Void> createItem(@ModelAttribute @Valid ItemCreateRequest itemCreateRequest) {
         itemService.createItem(itemCreateRequest);
@@ -46,8 +49,9 @@ public class ItemController {
         return Response.success(HttpStatus.OK, "상품 목록 조회 성공!", items);
     }
 
+    @LoginChecking
     @DeleteMapping("/{itemId}")
-    public Response<Void> delete(@PathVariable Long itemId) {
+    public Response<Void> delete(@PathVariable(name = "itemId") Long itemId) {
         itemService.delete(itemId);
         return Response.success(HttpStatus.OK, "상품 삭제 완료!");
     }

--- a/src/main/java/com/api/farmingsoon/domain/item/domain/Item.java
+++ b/src/main/java/com/api/farmingsoon/domain/item/domain/Item.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE item SET deleted_at = true WHERE id = ?")
-@SQLRestriction("deleted_at IS NOT NULL")
 public class Item extends BaseTimeEntity {
 
     @Id
@@ -21,6 +20,7 @@ public class Item extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @Setter
     private Member member;
 
     @Column(length = 100)

--- a/src/main/java/com/api/farmingsoon/domain/member/model/Member.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/model/Member.java
@@ -14,7 +14,6 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member SET deleted_at = NOW() WHERE id = ?")
-@SQLRestriction("deleted_at IS NOT NULL")
 public class Member extends BaseTimeEntity {
 
     @Id


### PR DESCRIPTION
## 💡 관련 이슈

- #16 

## ✅ 작업 상세 내용

- PreAuthorize() 는 로그인 여부나 권한체킹하는 것을 도와줍니다. success or fail로 동작하며 인증/인가 실패 시AccessDeniedException을 반환합니다.

- 여기서 문제점은 실패의 원인이 로그인을 안해서인지 권한이 없어서인지 
등을 구분하기 어렵고 따로 구체적인 예외처리가 불가능합니다.

- 또한 권한 체킹을 할 때 preAuthorize로 Role에 대해서 체크한 뒤 서비스에서 한번 더 자신의 게시글인지에 대해 확인해야 하는 로직이 필요합니다.

- 로그인 여부 검증은 어노테이션 생성 후 AOP를 적용했고 권한 검증은 서비스 단에서 AuthenticationUtils로 공통 처리했습니다.

## ⭐ 특이사항

## 📃 참고할만한 자료

This closed #16 
