### PR TITLE
토큰 생성 버그 수정

### DIFF
--- a/src/main/java/com/api/farmingsoon/common/security/jwt/JwtProvider.java
+++ b/src/main/java/com/api/farmingsoon/common/security/jwt/JwtProvider.java
@@ -77,7 +77,7 @@ public class JwtProvider {
                 .setExpiration(expiredDate) // 만료기간
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
-        jwtUtils.setRefreshToken(claims.getSubject(), refreshToken);
+        jwtUtils.setRefreshToken(refreshToken, claims.getSubject());
         return  refreshToken;
     }
 

--- a/src/main/java/com/api/farmingsoon/common/security/jwt/JwtProvider.java
+++ b/src/main/java/com/api/farmingsoon/common/security/jwt/JwtProvider.java
@@ -55,6 +55,7 @@ public class JwtProvider {
 
         Date now = new Date();
         Claims claims = Jwts.claims().setSubject(username);
+        claims.put("currentTimeMillis", System.currentTimeMillis());
         claims.put("roles", authorities);
 
         String accessToken = createAccessToken(claims, new Date(now.getTime() + accessExpirationTime));


### PR DESCRIPTION
## 💡 관련 이슈

- #39 

## ✅ 작업 상세 내용

- RefreshToken을 Redis에 설정하는 과정에서 key와 value를 반대로 적어두어 오류가 발생하여 수정했씁니다.
- claims값이 모두 같다면 같은 refreshToken을 생성하는 문제가 생깁니다. claims에 현재 시간 정보를 추가하여 해결했습니다.
 
## ⭐ 특이사항

## 📃 참고할만한 자료

This closed #39 