### PR TITLE
상품 목록 조회 버그 수정

### DIFF
--- a/src/main/java/com/api/farmingsoon/common/util/AuthenticationUtils.java
+++ b/src/main/java/com/api/farmingsoon/common/util/AuthenticationUtils.java
@@ -10,6 +10,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Component
 public class AuthenticationUtils {
@@ -45,5 +47,8 @@ public class AuthenticationUtils {
     {
         return memberService.getMemberByEmail(SecurityContextHolder.getContext().getAuthentication().getName());
     }
-
+    public Optional<Member> getOptionalMember()
+    {
+        return memberService.getOptionalMemberByEmail(SecurityContextHolder.getContext().getAuthentication().getName());
+    }
 }

--- a/src/main/java/com/api/farmingsoon/domain/bid/controller/BidController.java
+++ b/src/main/java/com/api/farmingsoon/domain/bid/controller/BidController.java
@@ -1,6 +1,7 @@
 package com.api.farmingsoon.domain.bid.controller;
 
 import com.api.farmingsoon.common.response.Response;
+import com.api.farmingsoon.domain.bid.dto.BidListResponse;
 import com.api.farmingsoon.domain.bid.dto.BidRequest;
 import com.api.farmingsoon.domain.bid.service.BidService;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +14,11 @@ import org.springframework.web.bind.annotation.*;
 public class BidController {
 
     private final BidService bidService;
-
+    @GetMapping
+    public Response<BidListResponse> getAllBid(@RequestParam(name = "itemId") Long itemId) {
+        BidListResponse itemBidList = bidService.getItemBidList(itemId);
+        return Response.success(HttpStatus.OK, "상품의 입찰 목록 조회 성공!", itemBidList);
+    }
     @PostMapping
     public Response<Void> bid(@RequestBody BidRequest bidRequest) {
         bidService.bid(bidRequest);

--- a/src/main/java/com/api/farmingsoon/domain/bid/controller/BidController.java
+++ b/src/main/java/com/api/farmingsoon/domain/bid/controller/BidController.java
@@ -5,6 +5,9 @@ import com.api.farmingsoon.domain.bid.dto.BidListResponse;
 import com.api.farmingsoon.domain.bid.dto.BidRequest;
 import com.api.farmingsoon.domain.bid.service.BidService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,8 +18,12 @@ public class BidController {
 
     private final BidService bidService;
     @GetMapping
-    public Response<BidListResponse> getAllBid(@RequestParam(name = "itemId") Long itemId) {
-        BidListResponse itemBidList = bidService.getItemBidList(itemId);
+    public Response<BidListResponse> getAllBid(
+            @RequestParam(name = "itemId") Long itemId,
+            @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+        )
+    {
+        BidListResponse itemBidList = bidService.getItemBidList(itemId, pageable);
         return Response.success(HttpStatus.OK, "상품의 입찰 목록 조회 성공!", itemBidList);
     }
     @PostMapping

--- a/src/main/java/com/api/farmingsoon/domain/bid/repository/BidRepository.java
+++ b/src/main/java/com/api/farmingsoon/domain/bid/repository/BidRepository.java
@@ -12,5 +12,5 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
 
     void deleteAllByMember(Member member);
 
-    Page<Bid> findAllByItemId(Long itemId);
+    Page<Bid> findAllByItemId(Long itemId, Pageable pageable);
 }

--- a/src/main/java/com/api/farmingsoon/domain/bid/repository/BidRepository.java
+++ b/src/main/java/com/api/farmingsoon/domain/bid/repository/BidRepository.java
@@ -11,4 +11,6 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
     Page<Bid> findAllByMember(Member member, Pageable pageable);
 
     void deleteAllByMember(Member member);
+
+    Page<Bid> findAllByItemId(Long itemId);
 }

--- a/src/main/java/com/api/farmingsoon/domain/bid/service/BidService.java
+++ b/src/main/java/com/api/farmingsoon/domain/bid/service/BidService.java
@@ -1,6 +1,6 @@
 package com.api.farmingsoon.domain.bid.service;
 
-import com.api.farmingsoon.domain.notification.event.BidRegisterEvent;
+import com.api.farmingsoon.domain.bid.dto.BidListResponse;
 import com.api.farmingsoon.common.exception.ErrorCode;
 import com.api.farmingsoon.common.exception.custom_exception.NotFoundException;
 import com.api.farmingsoon.common.util.AuthenticationUtils;
@@ -13,7 +13,6 @@ import com.api.farmingsoon.domain.item.repository.ItemRepository;
 import com.api.farmingsoon.domain.member.model.Member;
 import com.api.farmingsoon.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -55,5 +54,10 @@ public class BidService {
     @Transactional(readOnly = true)
     public Page<Bid> getMyBidList(Member member, Pageable pageable){
         return bidRepository.findAllByMember(member, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public BidListResponse getItemBidList(Long itemId) {
+        return BidListResponse.of(bidRepository.findAllByItemId(itemId));
     }
 }

--- a/src/main/java/com/api/farmingsoon/domain/bid/service/BidService.java
+++ b/src/main/java/com/api/farmingsoon/domain/bid/service/BidService.java
@@ -57,7 +57,7 @@ public class BidService {
     }
 
     @Transactional(readOnly = true)
-    public BidListResponse getItemBidList(Long itemId) {
-        return BidListResponse.of(bidRepository.findAllByItemId(itemId));
+    public BidListResponse getItemBidList(Long itemId, Pageable pageable) {
+        return BidListResponse.of(bidRepository.findAllByItemId(itemId, pageable));
     }
 }

--- a/src/main/java/com/api/farmingsoon/domain/item/controller/ItemController.java
+++ b/src/main/java/com/api/farmingsoon/domain/item/controller/ItemController.java
@@ -3,9 +3,7 @@ package com.api.farmingsoon.domain.item.controller;
 
 import com.api.farmingsoon.common.annotation.LoginChecking;
 import com.api.farmingsoon.common.response.Response;
-import com.api.farmingsoon.domain.item.dto.ItemCreateRequest;
-import com.api.farmingsoon.domain.item.dto.ItemDetailResponse;
-import com.api.farmingsoon.domain.item.dto.ItemListResponse;
+import com.api.farmingsoon.domain.item.dto.*;
 import com.api.farmingsoon.domain.item.service.ItemService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -47,17 +45,17 @@ public class ItemController {
         return Response.success(HttpStatus.OK, "상품 목록 조회 성공!", items);
     }
     @GetMapping("/me")
-    public Response<ItemListResponse> getMyItemList(
+    public Response<MyItemListResponse> getMyItemList(
             @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        ItemListResponse items = itemService.getMyItemList(pageable);
+        MyItemListResponse items = itemService.getMyItemList(pageable);
         return Response.success(HttpStatus.OK, "내가 등록한 아이템 조회 성공!", items);
     }
 
     @GetMapping("/bid/me")
-    public Response<ItemListResponse> getMyBidItemList(
+    public Response<MyBidItemListResponse> getMyBidItemList(
             @PageableDefault(size = 12, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        ItemListResponse items = itemService.getMyBidItemList(pageable);
+        MyBidItemListResponse items = itemService.getMyBidItemList(pageable);
         return Response.success(HttpStatus.OK, "내가 입찰에 참가한 아이템 조회 성공!", items);
     }
     @LoginChecking

--- a/src/main/java/com/api/farmingsoon/domain/item/dto/ItemDetailResponse.java
+++ b/src/main/java/com/api/farmingsoon/domain/item/dto/ItemDetailResponse.java
@@ -3,7 +3,6 @@ package com.api.farmingsoon.domain.item.dto;
 import com.api.farmingsoon.domain.bid.model.Bid;
 import com.api.farmingsoon.domain.image.domain.Image;
 import com.api.farmingsoon.domain.item.domain.Item;
-import com.api.farmingsoon.domain.item.domain.ItemStatus;
 import com.api.farmingsoon.domain.like.model.LikeableItem;
 import com.api.farmingsoon.domain.member.model.Member;
 import lombok.Builder;
@@ -35,7 +34,8 @@ public class ItemDetailResponse {
     private Boolean likeStatus;
 
 
-    public static ItemDetailResponse fromEntity(Item item, Member viewer) {
+    public static ItemDetailResponse of(Item item, Optional<Member> viewer) {
+
         return ItemDetailResponse.builder()
                 .sellerId(item.getMember().getId())
                 .sellerProfileImgUrl(item.getMember().getProfileImg())
@@ -52,7 +52,11 @@ public class ItemDetailResponse {
                 .likeCount(item.getLikeableItemList().size())
                 .thumbnailImgUrl(item.getThumbnailImageUrl())
                 .itemImgUrl(item.getImageList().stream().map(Image::getImageUrl).toList())
-                .likeStatus(item.getLikeableItemList().stream().map(LikeableItem::getMember).toList().contains(viewer))
+                .likeStatus // 조회자 세션이 존재할 경우에만 비교를 한다.
+                    (
+                        viewer.isPresent() ?
+                        item.getLikeableItemList().stream().map(LikeableItem::getMember).toList().contains(viewer) : false
+                    )
                 .build();
     }
 

--- a/src/main/java/com/api/farmingsoon/domain/item/dto/LikeableItemListResponse.java
+++ b/src/main/java/com/api/farmingsoon/domain/item/dto/LikeableItemListResponse.java
@@ -3,39 +3,38 @@ package com.api.farmingsoon.domain.item.dto;
 import com.api.farmingsoon.common.pagenation.Pagination;
 import com.api.farmingsoon.domain.bid.model.Bid;
 import com.api.farmingsoon.domain.item.domain.Item;
-import com.api.farmingsoon.domain.like.model.LikeableItem;
-import com.api.farmingsoon.domain.member.model.Member;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Getter
 @NoArgsConstructor
-public class ItemListResponse {
-
-    private List<ItemResponse> items; // 상품 데이터
-    private Pagination<ItemResponse> pagination; // 페이지 관련 데이터
+public class LikeableItemListResponse {
+    private List<LikeableItemResponse> items; // 상품 데이터
+    private Pagination<LikeableItemResponse> pagination; // 페이지 관련 데이터
 
     @Builder
-    public ItemListResponse(List<ItemResponse> items, Pagination<ItemResponse> pagination) {
+    public LikeableItemListResponse(List<LikeableItemResponse> items, Pagination<LikeableItemResponse> pagination) {
         this.items = items;
         this.pagination = pagination;
     }
 
-    public static ItemListResponse of(Page<Item> itemPage, Optional<Member> viewer) {
-        Page<ItemResponse> itemDtoPage = itemPage.map(item -> ItemResponse.of(item, viewer)); // Page<Item> -> Page<ItemDto>
-        return ItemListResponse.builder()
-                .items(itemDtoPage.getContent())
-                .pagination(Pagination.of(itemDtoPage))
+    public static LikeableItemListResponse of(Page<Item> itemPage) {
+        Page<LikeableItemResponse> myItemResponsePage = itemPage.map(item -> LikeableItemResponse.of(item));// Page<Item> -> Page<ItemDto>
+
+        return LikeableItemListResponse.builder()
+                .items(myItemResponsePage.getContent())
+                .pagination(Pagination.of(myItemResponsePage))
                 .build();
     }
 
     @Getter
     @NoArgsConstructor
-    public static class ItemResponse {
+    public static class LikeableItemResponse {
 
         private Long itemId; // 상품 접근
         private String title;
@@ -49,9 +48,8 @@ public class ItemListResponse {
         private Integer likeCount;
         private Integer viewCount;
         private String thumbnailImgUrl;
-        private Boolean likeStatus;
         @Builder
-        private ItemResponse(Long itemId, String title, String description, LocalDateTime expiredAt, Integer highestPrice, Integer hopePrice, Integer lowestPrice, String itemStatus, Integer bidCount, Integer likeCount, Integer viewCount, String thumbnailImgUrl, Boolean likeStatus) {
+        private LikeableItemResponse(Long itemId, String title, String description, LocalDateTime expiredAt, Integer highestPrice, Integer hopePrice, Integer lowestPrice, String itemStatus, Integer bidCount, Integer likeCount, Integer viewCount, String thumbnailImgUrl, Boolean likeStatus) {
             this.itemId = itemId;
             this.title = title;
             this.description = description;
@@ -64,12 +62,11 @@ public class ItemListResponse {
             this.likeCount = likeCount;
             this.viewCount = viewCount;
             this.thumbnailImgUrl = thumbnailImgUrl;
-            this.likeStatus = likeStatus;
         }
 
-        private static ItemResponse of(Item item, Optional<Member> viewer) {
+        private static LikeableItemResponse of(Item item) {
 
-            return ItemResponse.builder()
+            return LikeableItemResponse.builder()
                     .itemId(item.getId())
                     .title(item.getTitle())
                     .description(item.getDescription())
@@ -82,11 +79,6 @@ public class ItemListResponse {
                     .viewCount(item.getViewCount())
                     .likeCount(item.getLikeableItemList().size())
                     .thumbnailImgUrl(item.getThumbnailImageUrl())
-                    .likeStatus // 조회자 세션이 존재할 경우에만 비교를 한다.
-                            (
-                                    viewer.isPresent() ?
-                                            item.getLikeableItemList().stream().map(LikeableItem::getMember).toList().contains(viewer) : false
-                            )
                     .build();
         }
     }

--- a/src/main/java/com/api/farmingsoon/domain/item/dto/MyBidItemListResponse.java
+++ b/src/main/java/com/api/farmingsoon/domain/item/dto/MyBidItemListResponse.java
@@ -5,37 +5,38 @@ import com.api.farmingsoon.domain.bid.model.Bid;
 import com.api.farmingsoon.domain.item.domain.Item;
 import com.api.farmingsoon.domain.like.model.LikeableItem;
 import com.api.farmingsoon.domain.member.model.Member;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Getter
 @NoArgsConstructor
-public class ItemListResponse {
-
-    private List<ItemResponse> items; // 상품 데이터
-    private Pagination<ItemResponse> pagination; // 페이지 관련 데이터
+public class MyBidItemListResponse {
+    private List<MyBidItemResponse> items; // 상품 데이터
+    private Pagination<MyBidItemResponse> pagination; // 페이지 관련 데이터
 
     @Builder
-    public ItemListResponse(List<ItemResponse> items, Pagination<ItemResponse> pagination) {
+    public MyBidItemListResponse(List<MyBidItemResponse> items, Pagination<MyBidItemResponse> pagination) {
         this.items = items;
         this.pagination = pagination;
     }
 
-    public static ItemListResponse of(Page<Item> itemPage, Optional<Member> viewer) {
-        Page<ItemResponse> itemDtoPage = itemPage.map(item -> ItemResponse.of(item, viewer)); // Page<Item> -> Page<ItemDto>
-        return ItemListResponse.builder()
-                .items(itemDtoPage.getContent())
-                .pagination(Pagination.of(itemDtoPage))
+    public static MyBidItemListResponse of(Page<Item> itemPage, Member viewer) {
+        Page<MyBidItemResponse> myItemResponsePage = itemPage.map(item -> MyBidItemResponse.of(item, viewer));
+
+        return MyBidItemListResponse.builder()
+                .items(myItemResponsePage.getContent())
+                .pagination(Pagination.of(myItemResponsePage))
                 .build();
     }
 
     @Getter
     @NoArgsConstructor
-    public static class ItemResponse {
+    public static class MyBidItemResponse {
 
         private Long itemId; // 상품 접근
         private String title;
@@ -49,9 +50,8 @@ public class ItemListResponse {
         private Integer likeCount;
         private Integer viewCount;
         private String thumbnailImgUrl;
-        private Boolean likeStatus;
         @Builder
-        private ItemResponse(Long itemId, String title, String description, LocalDateTime expiredAt, Integer highestPrice, Integer hopePrice, Integer lowestPrice, String itemStatus, Integer bidCount, Integer likeCount, Integer viewCount, String thumbnailImgUrl, Boolean likeStatus) {
+        private MyBidItemResponse(Long itemId, String title, String description, LocalDateTime expiredAt, Integer highestPrice, Integer hopePrice, Integer lowestPrice, String itemStatus, Integer bidCount, Integer likeCount, Integer viewCount, String thumbnailImgUrl, Boolean likeStatus) {
             this.itemId = itemId;
             this.title = title;
             this.description = description;
@@ -64,12 +64,11 @@ public class ItemListResponse {
             this.likeCount = likeCount;
             this.viewCount = viewCount;
             this.thumbnailImgUrl = thumbnailImgUrl;
-            this.likeStatus = likeStatus;
         }
 
-        private static ItemResponse of(Item item, Optional<Member> viewer) {
+        private static MyBidItemResponse of(Item item, Member viewer) {
 
-            return ItemResponse.builder()
+            return MyBidItemResponse.builder()
                     .itemId(item.getId())
                     .title(item.getTitle())
                     .description(item.getDescription())
@@ -82,11 +81,7 @@ public class ItemListResponse {
                     .viewCount(item.getViewCount())
                     .likeCount(item.getLikeableItemList().size())
                     .thumbnailImgUrl(item.getThumbnailImageUrl())
-                    .likeStatus // 조회자 세션이 존재할 경우에만 비교를 한다.
-                            (
-                                    viewer.isPresent() ?
-                                            item.getLikeableItemList().stream().map(LikeableItem::getMember).toList().contains(viewer) : false
-                            )
+                    .likeStatus(item.getLikeableItemList().stream().map(LikeableItem::getMember).toList().contains(viewer))
                     .build();
         }
     }

--- a/src/main/java/com/api/farmingsoon/domain/item/dto/MyItemListResponse.java
+++ b/src/main/java/com/api/farmingsoon/domain/item/dto/MyItemListResponse.java
@@ -3,39 +3,38 @@ package com.api.farmingsoon.domain.item.dto;
 import com.api.farmingsoon.common.pagenation.Pagination;
 import com.api.farmingsoon.domain.bid.model.Bid;
 import com.api.farmingsoon.domain.item.domain.Item;
-import com.api.farmingsoon.domain.like.model.LikeableItem;
-import com.api.farmingsoon.domain.member.model.Member;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Getter
 @NoArgsConstructor
-public class ItemListResponse {
-
-    private List<ItemResponse> items; // 상품 데이터
-    private Pagination<ItemResponse> pagination; // 페이지 관련 데이터
+public class MyItemListResponse {
+    private List<MyItemResponse> items; // 상품 데이터
+    private Pagination<MyItemResponse> pagination; // 페이지 관련 데이터
 
     @Builder
-    public ItemListResponse(List<ItemResponse> items, Pagination<ItemResponse> pagination) {
+    public MyItemListResponse(List<MyItemResponse> items, Pagination<MyItemResponse> pagination) {
         this.items = items;
         this.pagination = pagination;
     }
 
-    public static ItemListResponse of(Page<Item> itemPage, Optional<Member> viewer) {
-        Page<ItemResponse> itemDtoPage = itemPage.map(item -> ItemResponse.of(item, viewer)); // Page<Item> -> Page<ItemDto>
-        return ItemListResponse.builder()
-                .items(itemDtoPage.getContent())
-                .pagination(Pagination.of(itemDtoPage))
+    public static MyItemListResponse of(Page<Item> itemPage) {
+        Page<MyItemResponse> myItemResponsePage = itemPage.map(item -> MyItemResponse.of(item));// Page<Item> -> Page<ItemDto>
+
+        return MyItemListResponse.builder()
+                .items(myItemResponsePage.getContent())
+                .pagination(Pagination.of(myItemResponsePage))
                 .build();
     }
 
     @Getter
     @NoArgsConstructor
-    public static class ItemResponse {
+    public static class MyItemResponse {
 
         private Long itemId; // 상품 접근
         private String title;
@@ -49,9 +48,8 @@ public class ItemListResponse {
         private Integer likeCount;
         private Integer viewCount;
         private String thumbnailImgUrl;
-        private Boolean likeStatus;
         @Builder
-        private ItemResponse(Long itemId, String title, String description, LocalDateTime expiredAt, Integer highestPrice, Integer hopePrice, Integer lowestPrice, String itemStatus, Integer bidCount, Integer likeCount, Integer viewCount, String thumbnailImgUrl, Boolean likeStatus) {
+        private MyItemResponse(Long itemId, String title, String description, LocalDateTime expiredAt, Integer highestPrice, Integer hopePrice, Integer lowestPrice, String itemStatus, Integer bidCount, Integer likeCount, Integer viewCount, String thumbnailImgUrl, Boolean likeStatus) {
             this.itemId = itemId;
             this.title = title;
             this.description = description;
@@ -64,12 +62,11 @@ public class ItemListResponse {
             this.likeCount = likeCount;
             this.viewCount = viewCount;
             this.thumbnailImgUrl = thumbnailImgUrl;
-            this.likeStatus = likeStatus;
         }
 
-        private static ItemResponse of(Item item, Optional<Member> viewer) {
+        private static MyItemResponse of(Item item) {
 
-            return ItemResponse.builder()
+            return MyItemResponse.builder()
                     .itemId(item.getId())
                     .title(item.getTitle())
                     .description(item.getDescription())
@@ -82,11 +79,6 @@ public class ItemListResponse {
                     .viewCount(item.getViewCount())
                     .likeCount(item.getLikeableItemList().size())
                     .thumbnailImgUrl(item.getThumbnailImageUrl())
-                    .likeStatus // 조회자 세션이 존재할 경우에만 비교를 한다.
-                            (
-                                    viewer.isPresent() ?
-                                            item.getLikeableItemList().stream().map(LikeableItem::getMember).toList().contains(viewer) : false
-                            )
                     .build();
         }
     }

--- a/src/main/java/com/api/farmingsoon/domain/item/service/ItemService.java
+++ b/src/main/java/com/api/farmingsoon/domain/item/service/ItemService.java
@@ -1,5 +1,6 @@
 package com.api.farmingsoon.domain.item.service;
 
+import com.api.farmingsoon.domain.item.dto.*;
 import com.api.farmingsoon.domain.member.model.Member;
 import com.api.farmingsoon.common.event.UploadImagesRollbackEvent;
 import com.api.farmingsoon.common.exception.ErrorCode;
@@ -12,9 +13,6 @@ import com.api.farmingsoon.domain.image.domain.Image;
 import com.api.farmingsoon.domain.image.service.ImageService;
 import com.api.farmingsoon.domain.item.domain.Item;
 import com.api.farmingsoon.domain.item.domain.ItemStatus;
-import com.api.farmingsoon.domain.item.dto.ItemCreateRequest;
-import com.api.farmingsoon.domain.item.dto.ItemDetailResponse;
-import com.api.farmingsoon.domain.item.dto.ItemListResponse;
 import com.api.farmingsoon.domain.item.repository.ItemRepository;
 import com.api.farmingsoon.domain.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -68,14 +67,14 @@ public class ItemService {
     }
     @Transactional(readOnly = true)
     public ItemListResponse getItemList(String category, String keyword, Pageable pageable, String sortcode) {
-        Member viewer = authenticationUtils.getAuthenticationMember();
+        Optional<Member> viewer = authenticationUtils.getOptionalMember();
         return ItemListResponse.of(itemRepository.findItemList(category, keyword, pageable, sortcode), viewer);
     }
     @Transactional(readOnly = true)
     public ItemDetailResponse getItemDetail(Long itemId) {
-        Member viewer = authenticationUtils.getAuthenticationMember();
+        Optional<Member> viewer = authenticationUtils.getOptionalMember();
         Item item = itemRepository.findById(itemId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ITEM));
-        return ItemDetailResponse.fromEntity(item, viewer);
+        return ItemDetailResponse.of(item, viewer);
     }
 
     @Transactional
@@ -91,17 +90,16 @@ public class ItemService {
         return itemRepository.findById(itemId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ITEM));
     }
     @Transactional(readOnly = true)
-    public ItemListResponse getMyItemList(Pageable pageable) {
-        Member viewer = authenticationUtils.getAuthenticationMember();
-        return ItemListResponse.of(itemRepository.findAllByMember(authenticationUtils.getAuthenticationMember(), pageable), viewer);
+    public MyItemListResponse getMyItemList(Pageable pageable) {
+        return MyItemListResponse.of(itemRepository.findAllByMember(authenticationUtils.getAuthenticationMember(), pageable));
     }
 
     @Transactional(readOnly = true)
-    public ItemListResponse getMyBidItemList(Pageable pageable) {
+    public MyBidItemListResponse getMyBidItemList(Pageable pageable) {
         Member viewer = authenticationUtils.getAuthenticationMember();
         Page<Bid> myBidList = bidService.getMyBidList(viewer, pageable);
 
-        return ItemListResponse.of(myBidList.map(Bid::getItem), viewer);
+        return MyBidItemListResponse.of(myBidList.map(Bid::getItem), viewer);
     }
 
     /**

--- a/src/main/java/com/api/farmingsoon/domain/like/controller/LikeableItemController.java
+++ b/src/main/java/com/api/farmingsoon/domain/like/controller/LikeableItemController.java
@@ -2,6 +2,7 @@ package com.api.farmingsoon.domain.like.controller;
 
 import com.api.farmingsoon.common.response.Response;
 import com.api.farmingsoon.domain.item.dto.ItemListResponse;
+import com.api.farmingsoon.domain.item.dto.LikeableItemListResponse;
 import com.api.farmingsoon.domain.like.service.LikeableItemService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +33,7 @@ public class LikeableItemController {
     }
 
     @GetMapping("/me")
-    public Response<ItemListResponse> getLikeableItemList(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    public Response<LikeableItemListResponse> getLikeableItemList(@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return Response.success(HttpStatus.OK, "좋아요를 누른 상품 목록 조회 성공", likeableItemService.likableItemList(pageable));
     }
 }

--- a/src/main/java/com/api/farmingsoon/domain/like/service/LikeableItemService.java
+++ b/src/main/java/com/api/farmingsoon/domain/like/service/LikeableItemService.java
@@ -6,6 +6,7 @@ import com.api.farmingsoon.common.exception.custom_exception.NotFoundException;
 import com.api.farmingsoon.common.util.AuthenticationUtils;
 import com.api.farmingsoon.domain.item.domain.Item;
 import com.api.farmingsoon.domain.item.dto.ItemListResponse;
+import com.api.farmingsoon.domain.item.dto.LikeableItemListResponse;
 import com.api.farmingsoon.domain.item.repository.ItemRepository;
 import com.api.farmingsoon.domain.like.model.LikeableItem;
 import com.api.farmingsoon.domain.like.repository.LikeableItemRepository;
@@ -49,9 +50,9 @@ public class LikeableItemService {
         likeableItemRepository.delete(likeableItem);
     }
     @Transactional(readOnly = true)
-    public ItemListResponse likableItemList(Pageable pageable) {
+    public LikeableItemListResponse likableItemList(Pageable pageable) {
         Member member = authenticationUtils.getAuthenticationMember();
         Page<LikeableItem> likeableItems = likeableItemRepository.findAllByMember(member, pageable);
-        return ItemListResponse.of(likeableItems.map(LikeableItem::getItem), member);
+        return LikeableItemListResponse.of(likeableItems.map(LikeableItem::getItem));
     }
 }

--- a/src/main/java/com/api/farmingsoon/domain/member/service/MemberService.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/service/MemberService.java
@@ -20,6 +20,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -92,6 +93,11 @@ public class MemberService {
     public Member getMemberByEmail(String email) {
         return memberRepository.findByEmail(email).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER));
     }
+    @Transactional(readOnly = true)
+    public Optional<Member> getOptionalMemberByEmail(String email) {
+        return memberRepository.findByEmail(email);
+    }
+
     @Transactional(readOnly = true)
     public Member getMemberById(Long memberId) {
         return memberRepository.findById(memberId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER));

--- a/src/test/java/com/api/farmingsoon/domain/item/controller/ItemControllerTest.java
+++ b/src/test/java/com/api/farmingsoon/domain/item/controller/ItemControllerTest.java
@@ -9,6 +9,7 @@ import com.api.farmingsoon.domain.bid.service.BidService;
 import com.api.farmingsoon.domain.item.domain.Item;
 import com.api.farmingsoon.domain.item.domain.ItemStatus;
 import com.api.farmingsoon.domain.item.dto.ItemListResponse;
+import com.api.farmingsoon.domain.item.dto.MyItemListResponse;
 import com.api.farmingsoon.domain.item.service.ItemService;
 import com.api.farmingsoon.domain.member.dto.JoinRequest;
 import com.api.farmingsoon.domain.member.service.MemberService;
@@ -368,12 +369,12 @@ class ItemControllerTest {
                 .andReturn();
 
         String result = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("result").toString();
-        ItemListResponse itemListResponse = objectMapper.readValue(result, ItemListResponse.class);
+        MyItemListResponse myItemListResponse = objectMapper.readValue(result, MyItemListResponse.class);
 
-        Assertions.assertThat(itemListResponse.getItems().get(0).getTitle()).isEqualTo("title20");
-        Assertions.assertThat(itemListResponse.getItems().get(11).getTitle()).isEqualTo("title9");
+        Assertions.assertThat(myItemListResponse.getItems().get(0).getTitle()).isEqualTo("title20");
+        Assertions.assertThat(myItemListResponse.getItems().get(11).getTitle()).isEqualTo("title9");
 
-        Assertions.assertThat(itemListResponse.getPagination()).isNotNull()
+        Assertions.assertThat(myItemListResponse.getPagination()).isNotNull()
                 .extracting("totalElementSize", "elementSize")
                 .contains(20L,12);
     }

--- a/src/test/java/com/api/farmingsoon/domain/like/controller/LikeableItemIntegrationTest.java
+++ b/src/test/java/com/api/farmingsoon/domain/like/controller/LikeableItemIntegrationTest.java
@@ -4,15 +4,13 @@ import com.api.farmingsoon.common.clean.DatabaseCleanup;
 import com.api.farmingsoon.common.util.TimeUtils;
 import com.api.farmingsoon.domain.item.domain.Item;
 import com.api.farmingsoon.domain.item.domain.ItemStatus;
-import com.api.farmingsoon.domain.item.dto.ItemListResponse;
+import com.api.farmingsoon.domain.item.dto.LikeableItemListResponse;
 import com.api.farmingsoon.domain.item.service.ItemService;
-import com.api.farmingsoon.domain.like.model.LikeableItem;
 import com.api.farmingsoon.domain.like.service.LikeableItemService;
 import com.api.farmingsoon.domain.member.dto.JoinRequest;
 import com.api.farmingsoon.domain.member.service.MemberService;
 import com.api.farmingsoon.util.TestImageUtils;
 import com.api.farmingsoon.util.Transaction;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -35,7 +33,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
@@ -178,9 +175,8 @@ class LikeableItemIntegrationTest {
                 .andReturn();
         //then
         String result = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("result").toString();
-        ItemListResponse itemListResponse = objectMapper.readValue(result, ItemListResponse.class);
+        LikeableItemListResponse likeableItemListResponse = objectMapper.readValue(result, LikeableItemListResponse.class);
 
-        Assertions.assertThat(itemListResponse.getItems().size()).isEqualTo(10);
-        Assertions.assertThat(itemListResponse.getItems().get(0).getLikeStatus()).isTrue();
+        Assertions.assertThat(likeableItemListResponse.getItems().size()).isEqualTo(10);
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈

- #73 

## ✅ 작업 상세 내용

- [ ] 사용자 인증 객체를 이용해 likeStatus를 체크하다 보니 인증되지 않은 사용자가 상품 목록을 조회할 수 없는 문제가 발생
-> Optional객체를 이용해 사용해 NotFoundException이 터지지 않도록 분기 처리 
- [ ] Optional객체의 사용으로 통합으로 사용하던 ItemListResponse를 api에 따라 모두 분리
- [ ] 상품의 입찰 목록 api추가

## ⭐ 특이사항

## 📃 참고할만한 자료

This closed #73 
