### PR TITLE
채팅 테스트 자동화 및 리팩토링

### DIFF
--- a/src/main/java/com/api/farmingsoon/domain/chat/dto/ChatResponse.java
+++ b/src/main/java/com/api/farmingsoon/domain/chat/dto/ChatResponse.java
@@ -3,11 +3,12 @@ package com.api.farmingsoon.domain.chat.dto;
 import com.api.farmingsoon.domain.chat.model.Chat;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-@Setter
+@NoArgsConstructor
 @Getter
 public class ChatResponse {
 

--- a/src/main/java/com/api/farmingsoon/domain/chat/dto/ChatResponse.java
+++ b/src/main/java/com/api/farmingsoon/domain/chat/dto/ChatResponse.java
@@ -12,19 +12,19 @@ import java.time.LocalDateTime;
 public class ChatResponse {
 
     private String message;
-    private String sender;
+    private Long senderId;
     private LocalDateTime createAt;
 
     @Builder
-    private ChatResponse(String sender, String message, LocalDateTime createAt) {
-        this.sender = sender;
+    private ChatResponse(Long senderId, String message, LocalDateTime createAt) {
+        this.senderId = senderId;
         this.message = message;
         this.createAt = createAt;
     }
     public static ChatResponse of(Chat chat) {
         return ChatResponse
                 .builder()
-                .sender(chat.getSender().getEmail())
+                .senderId(chat.getSender().getId())
                 .message(chat.getMessage())
                 .createAt(chat.getCreatedAt())
                 .build();

--- a/src/main/java/com/api/farmingsoon/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/com/api/farmingsoon/domain/chat/repository/ChatRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
-    Page<Chat> findByChatRoom(ChatRoom chatRoom, Pageable pageable);
+    Page<Chat> findByChatRoomOrderByIdDesc(ChatRoom chatRoom, Pageable pageable);
 }

--- a/src/main/java/com/api/farmingsoon/domain/chat/service/ChatService.java
+++ b/src/main/java/com/api/farmingsoon/domain/chat/service/ChatService.java
@@ -37,6 +37,6 @@ public class ChatService {
     @Transactional(readOnly = true)
     public ChatListResponse getChats(Long chatRoomId, Pageable pageable) {
         ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId);
-        return ChatListResponse.of(chatRepository.findByChatRoom(chatRoom, pageable));
+        return ChatListResponse.of(chatRepository.findByChatRoomOrderByIdDesc(chatRoom, pageable));
     }
 }

--- a/src/main/java/com/api/farmingsoon/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/api/farmingsoon/domain/chatroom/controller/ChatRoomController.java
@@ -23,11 +23,12 @@ public class ChatRoomController {
     private final ChatRoomService chatRoomService;
 
     @LoginChecking
-    @GetMapping
+    @GetMapping("/me")
     public Response<List<ChatRoomResponse>> getChatRoomList() {
         return Response.success(HttpStatus.OK,"나의 채팅방 목록", chatRoomService.getChatRooms());
     }
-    @GetMapping("{chatRoomId}")
+    @LoginChecking
+    @GetMapping("/{chatRoomId}")
     public ChatRoomDetailResponse getChatRoomDetail(@PathVariable(name = "chatRoomId") Long chatRoomId){
         return chatRoomService.getChatRoomDetail(chatRoomId);
     }

--- a/src/main/java/com/api/farmingsoon/domain/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/api/farmingsoon/domain/chatroom/controller/ChatRoomController.java
@@ -29,8 +29,8 @@ public class ChatRoomController {
     }
     @LoginChecking
     @GetMapping("/{chatRoomId}")
-    public ChatRoomDetailResponse getChatRoomDetail(@PathVariable(name = "chatRoomId") Long chatRoomId){
-        return chatRoomService.getChatRoomDetail(chatRoomId);
+    public Response<ChatRoomDetailResponse> getChatRoomDetail(@PathVariable(name = "chatRoomId") Long chatRoomId){
+        return Response.success(HttpStatus.OK, "채팅방 상세", chatRoomService.getChatRoomDetail(chatRoomId));
     }
 
     /**

--- a/src/main/java/com/api/farmingsoon/domain/chatroom/dto/ChatRoomCreateRequest.java
+++ b/src/main/java/com/api/farmingsoon/domain/chatroom/dto/ChatRoomCreateRequest.java
@@ -13,21 +13,21 @@ public class ChatRoomCreateRequest {
      * 추후에 모든 회원들은 nickname을 이용하며 이 부분도 email이 아닌 nickname을 사용하도록 만들면 좋을 것 같습니다.
      */
     @NotNull
-    private String buyerName;
+    private Long buyerId;
 
     @NotNull
     private Long itemId;
 
     @Builder
-    public ChatRoomCreateRequest(String buyerName, Long itemId) {
-        this.buyerName = buyerName;
+    public ChatRoomCreateRequest(Long buyerId, Long itemId) {
+        this.buyerId = buyerId;
         this.itemId = itemId;
     }
 
-    public static ChatRoomCreateRequest of(String buyerName, Long itemId) {
+    public static ChatRoomCreateRequest of(Long buyerId, Long itemId) {
         return ChatRoomCreateRequest
                 .builder()
-                .buyerName(buyerName)
+                .buyerId(buyerId)
                 .itemId(itemId)
                 .build();
     }

--- a/src/main/java/com/api/farmingsoon/domain/chatroom/dto/ChatRoomDetailResponse.java
+++ b/src/main/java/com/api/farmingsoon/domain/chatroom/dto/ChatRoomDetailResponse.java
@@ -23,14 +23,11 @@ public class ChatRoomDetailResponse {
 
     private Integer highestPrice;
 
-    private String toUsername; // 상대방 식별
-
     private String toUserProfileImage;
 
 
     @Builder
-    private ChatRoomDetailResponse(String toUsername, String itemTitle, Integer highestPrice,String toUserProfileImage , String itemThumbnailImage,Long itemId) {
-        this.toUsername = toUsername;
+    private ChatRoomDetailResponse(String itemTitle, Integer highestPrice,String toUserProfileImage , String itemThumbnailImage,Long itemId) {
         this.itemTitle = itemTitle;
         this.highestPrice = highestPrice;
         this.itemThumbnailImage = itemThumbnailImage;
@@ -41,7 +38,6 @@ public class ChatRoomDetailResponse {
     public static ChatRoomDetailResponse of(ChatRoom chatRoom, String fromUsername) {
         Member toUser = ChatRoom.resolveToMember(chatRoom, fromUsername);
         return ChatRoomDetailResponse.builder()
-                .toUsername(toUser.getEmail())
                 .itemTitle(chatRoom.getItem().getTitle())
                 .highestPrice(chatRoom.getItem().getBidList().stream().map(Bid::getPrice).max(Integer::compareTo).orElse(null))
                 .itemId(chatRoom.getItem().getId())

--- a/src/main/java/com/api/farmingsoon/domain/chatroom/dto/ChatRoomResponse.java
+++ b/src/main/java/com/api/farmingsoon/domain/chatroom/dto/ChatRoomResponse.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,7 +36,8 @@ public class ChatRoomResponse {
 
     public static ChatRoomResponse of(ChatRoom chatRoom, String fromName) {
         Member toMember =  ChatRoom.resolveToMember(chatRoom, fromName);
-        Chat lastChat = chatRoom.getChatList().get(0);
+        List<Chat> chatList = chatRoom.getChatList();
+        Chat lastChat = chatList.get(chatList.size() - 1);
 
         return ChatRoomResponse.builder()
                 .chatRoomId(chatRoom.getId())

--- a/src/main/java/com/api/farmingsoon/domain/chatroom/dto/ChatRoomResponse.java
+++ b/src/main/java/com/api/farmingsoon/domain/chatroom/dto/ChatRoomResponse.java
@@ -34,14 +34,14 @@ public class ChatRoomResponse {
         this.lastChatTime = lastChatTime;
     }
 
-    public static ChatRoomResponse of(ChatRoom chatRoom, String fromName) {
-        Member toMember =  ChatRoom.resolveToMember(chatRoom, fromName);
+    public static ChatRoomResponse of(ChatRoom chatRoom, String fromUserEmail) {
+        Member toMember =  ChatRoom.resolveToMember(chatRoom, fromUserEmail);
         List<Chat> chatList = chatRoom.getChatList();
         Chat lastChat = chatList.get(chatList.size() - 1);
 
         return ChatRoomResponse.builder()
                 .chatRoomId(chatRoom.getId())
-                .toUserName(toMember.getEmail())
+                .toUserName(toMember.getNickname())
                 .toUserProfileImage(toMember.getProfileImg())
                 .lastMessage(lastChat.getMessage())
                 .lastChatTime(lastChat.getCreatedAt())

--- a/src/main/java/com/api/farmingsoon/domain/chatroom/model/ChatRoom.java
+++ b/src/main/java/com/api/farmingsoon/domain/chatroom/model/ChatRoom.java
@@ -58,8 +58,8 @@ public class ChatRoom extends BaseTimeEntity {
      * 판매자라면 상대방은 구매자
      * 반대라면 상대방은 판매자
      */
-    public static Member resolveToMember(ChatRoom chatRoom, String fromUsername) {
-        return chatRoom.seller.getEmail().equals(fromUsername) ?
+    public static Member resolveToMember(ChatRoom chatRoom, String fromUserEmail) {
+        return chatRoom.seller.getEmail().equals(fromUserEmail) ?
                 chatRoom.buyer :
                 chatRoom.seller;
     }

--- a/src/main/java/com/api/farmingsoon/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/api/farmingsoon/domain/chatroom/service/ChatRoomService.java
@@ -44,15 +44,15 @@ public class ChatRoomService {
     /**
      * @Description
      * 내가 판매자 또는 구매자로 참가하고 있는 채팅방 목록 조회
+     * 채팅이 하나라도 있어야 조회됨
      */
     @Transactional(readOnly = true)
     public List<ChatRoomResponse> getChatRooms() {
         Member fromMember = memberService.getMemberByEmail(authenticationUtils.getAuthenticationMember().getEmail());
         List<ChatRoom> myChatRooms = chatRoomRepository.findChatRoomByBuyerOrSeller(fromMember, fromMember);
-        return myChatRooms.stream().map
-                (
-                    chatRoom -> ChatRoomResponse.of(chatRoom, fromMember.getEmail())
-                )
+        return myChatRooms.stream().
+                filter(chatRoom -> !chatRoom.getChatList().isEmpty()).
+                map(chatRoom -> ChatRoomResponse.of(chatRoom, fromMember.getEmail()))
                 .toList();
     }
 
@@ -83,7 +83,6 @@ public class ChatRoomService {
         Member buyer = memberService.getMemberByEmail(chatRoomCreateRequest.getBuyerName());
         Member seller = item.getMember();
 
-        ChatRoom chatRoom = chatRoomRepository.findChatRoomByBuyerAndItem(buyer, item).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ITEM));
         Optional<ChatRoom> optionalChatRoom = chatRoomRepository.findChatRoomByBuyerAndItem(buyer, item);
 
         return optionalChatRoom.orElseGet(()

--- a/src/main/java/com/api/farmingsoon/domain/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/api/farmingsoon/domain/chatroom/service/ChatRoomService.java
@@ -63,11 +63,11 @@ public class ChatRoomService {
      */
     @Transactional(readOnly = true)
     public ChatRoomDetailResponse getChatRoomDetail(Long chatRoomId) {
-        String fromUsername = authenticationUtils.getAuthenticationMember().getEmail();
+        String fromUserEmail = authenticationUtils.getAuthenticationMember().getEmail();
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_CHATROOM));
 
-        return ChatRoomDetailResponse.of(chatRoom, fromUsername);
+        return ChatRoomDetailResponse.of(chatRoom, fromUserEmail);
     }
 
 
@@ -80,7 +80,7 @@ public class ChatRoomService {
     @Transactional
     public Long handleChatRoom(ChatRoomCreateRequest chatRoomCreateRequest) {
         Item item = itemService.getItemById(chatRoomCreateRequest.getItemId());
-        Member buyer = memberService.getMemberByEmail(chatRoomCreateRequest.getBuyerName());
+        Member buyer = memberService.getMemberById(chatRoomCreateRequest.getBuyerId());
         Member seller = item.getMember();
 
         Optional<ChatRoom> optionalChatRoom = chatRoomRepository.findChatRoomByBuyerAndItem(buyer, item);

--- a/src/main/java/com/api/farmingsoon/domain/item/dto/ItemCreateRequest.java
+++ b/src/main/java/com/api/farmingsoon/domain/item/dto/ItemCreateRequest.java
@@ -21,6 +21,8 @@ public class ItemCreateRequest {
 
     private String description;
 
+    private String category;
+
     private Integer hopePrice;
 
     private Integer period;
@@ -30,10 +32,11 @@ public class ItemCreateRequest {
     private List<MultipartFile> images;
 
     @Builder
-    private ItemCreateRequest(String title, String description, Integer hopePrice, Integer period, MultipartFile thumbnailImage, List<MultipartFile> images) {
+    private ItemCreateRequest(String title, String description, Integer hopePrice,String category, Integer period, MultipartFile thumbnailImage, List<MultipartFile> images) {
         this.title = title;
         this.description = description;
         this.hopePrice = hopePrice;
+        this.category = category;
         this.period = period;
         this.thumbnailImage = thumbnailImage;
         this.images = images;
@@ -44,6 +47,7 @@ public class ItemCreateRequest {
                 .title(this.title)
                 .description(this.description)
                 .hopePrice(this.hopePrice)
+                .category(category)
                 .expiredAt(TimeUtils.setExpireAt(period))
                 .itemStatus(ItemStatus.BIDDING)
                 .build();

--- a/src/test/java/com/api/farmingsoon/domain/chatting/ChattingIntegrationTest.java
+++ b/src/test/java/com/api/farmingsoon/domain/chatting/ChattingIntegrationTest.java
@@ -1,0 +1,241 @@
+package com.api.farmingsoon.domain.chatting;
+
+import com.api.farmingsoon.common.clean.DatabaseCleanup;
+import com.api.farmingsoon.common.util.TimeUtils;
+import com.api.farmingsoon.domain.bid.dto.BidRequest;
+import com.api.farmingsoon.domain.bid.service.BidService;
+import com.api.farmingsoon.domain.chat.dto.ChatMessageRequest;
+import com.api.farmingsoon.domain.chat.service.ChatService;
+import com.api.farmingsoon.domain.chatroom.dto.ChatRoomCreateRequest;
+import com.api.farmingsoon.domain.chatroom.dto.ChatRoomResponse;
+import com.api.farmingsoon.domain.chatroom.model.ChatRoom;
+import com.api.farmingsoon.domain.chatroom.service.ChatRoomService;
+import com.api.farmingsoon.domain.item.domain.Item;
+import com.api.farmingsoon.domain.item.domain.ItemStatus;
+import com.api.farmingsoon.domain.item.service.ItemService;
+import com.api.farmingsoon.domain.member.dto.JoinRequest;
+import com.api.farmingsoon.domain.member.service.MemberService;
+import com.api.farmingsoon.util.TestImageUtils;
+import com.api.farmingsoon.util.Transaction;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+public class ChattingIntegrationTest {
+
+    @Autowired
+    private ItemService itemService;
+    @Autowired
+    private MemberService memberService;
+    @Autowired
+    private WebApplicationContext ctx;
+    @Autowired
+    private ChatService chatService;
+    @Autowired
+    private ChatRoomService chatRoomService;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private Transaction transaction;
+
+    @Autowired
+    private DatabaseCleanup databaseCleanup;
+
+    private static MockMultipartFile profileImage;
+
+    @BeforeAll
+    static void beforeAll() throws IOException {
+        profileImage = TestImageUtils.generateMockImageFile("profileImage");
+    }
+
+    @BeforeEach
+    void beforeEach(){
+        databaseCleanup.execute();
+        for(int i = 1; i <= 2; i++){
+            JoinRequest joinRequest = JoinRequest.builder()
+                    .email("user" + i + "@naver.com")
+                    .nickname("user1")
+                    .password("12345678")
+                    .profileImg(profileImage).build();
+
+            memberService.join(joinRequest);
+        }
+
+        Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_MEMBER"));
+
+        UserDetails principal = new User("user1@naver.com", "", authorities);
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(principal, "", authorities));
+
+
+        Item item = Item.builder()
+                .title("title")
+                .description("description")
+                .hopePrice(10000)
+                .itemStatus(ItemStatus.BIDDING)
+                .viewCount(0)
+                .expiredAt(TimeUtils.setExpireAt(3)).build();
+
+        List<String> imageUrl = new ArrayList<>(Arrays.asList("/subFile1", "/subFile2" , "/subFile3"));
+        imageUrl.add(0, "/thumnailImage");
+
+        itemService.saveItemAndImage(item, imageUrl);
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(ctx)
+                .addFilters(new CharacterEncodingFilter("UTF-8", true))  // 필터 추가
+                .alwaysDo(print())
+                .build();
+    }
+
+    @DisplayName("채팅방 생성(구매자 입장)")
+    @WithUserDetails(value = "user1@naver.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    void createChatRoomByBuyer() throws Exception {
+        //given
+        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of("user2@naver.com", 1L);
+
+        // when
+
+        MvcResult mvcResult = mockMvc.perform(post("/api/chat-rooms")
+                        .content(objectMapper.writeValueAsString(chatRoomCreateRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        Long chatRoomId = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("result").asLong();
+        
+        transaction.invoke(() ->
+            {
+            ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId);
+
+            Assertions.assertThat(chatRoom.getSeller().getEmail()).isEqualTo("user1@naver.com");
+            Assertions.assertThat(chatRoom.getBuyer().getEmail()).isEqualTo("user2@naver.com");
+            }
+        );
+
+    }
+    @DisplayName("채팅방 생성(판매자 입장)")
+    @WithUserDetails(value = "user2@naver.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    void createChatRoomBySeller() throws Exception {
+        //given
+        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of("user2@naver.com", 1L);
+
+        // when
+
+        MvcResult mvcResult = mockMvc.perform(post("/api/chat-rooms")
+                        .content(objectMapper.writeValueAsString(chatRoomCreateRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        Long chatRoomId = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("result").asLong();
+
+        transaction.invoke(() ->
+                {
+                    ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId);
+
+                    Assertions.assertThat(chatRoom.getSeller().getEmail()).isEqualTo("user1@naver.com");
+                    Assertions.assertThat(chatRoom.getBuyer().getEmail()).isEqualTo("user2@naver.com");
+                }
+        );
+
+    }
+
+    @DisplayName("채팅방 조회(판매자 입장)")
+    @WithUserDetails(value = "user1@naver.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    void getChatRoomBySeller() throws Exception {
+        //given
+        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of("user2@naver.com", 1L);
+        Long chatRoomId = chatRoomService.handleChatRoom(chatRoomCreateRequest);
+        chatService.create(ChatMessageRequest.builder().chatRoomId(chatRoomId).message("chat1").build());
+        chatService.create(ChatMessageRequest.builder().chatRoomId(chatRoomId).message("chat2").build());
+        // when
+
+        MvcResult mvcResult = mockMvc.perform(get("/api/chat-rooms/me"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+
+        String result = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("result").get(0).toString();
+        ChatRoomResponse chatRoomResponse = objectMapper.readValue(result, ChatRoomResponse.class);
+
+
+
+        Assertions.assertThat(chatRoomResponse.getToUserName()).isEqualTo("user2@naver.com");
+        Assertions.assertThat(chatRoomResponse.getLastMessage()).isEqualTo("chat2");
+
+
+    }
+
+    @DisplayName("채팅방 조회(구매자 입장)")
+    @WithUserDetails(value = "user2@naver.com", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @Test
+    void getChatRoomByBuyer() throws Exception {
+        //given
+        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of("user2@naver.com", 1L);
+        Long chatRoomId = chatRoomService.handleChatRoom(chatRoomCreateRequest);
+        chatService.create(ChatMessageRequest.builder().chatRoomId(chatRoomId).message("chat1").build());
+        chatService.create(ChatMessageRequest.builder().chatRoomId(chatRoomId).message("chat2").build());
+        chatService.create(ChatMessageRequest.builder().chatRoomId(chatRoomId).message("chat3").build());
+        // when
+
+        MvcResult mvcResult = mockMvc.perform(get("/api/chat-rooms/me"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        //then
+        String result = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("result").get(0).toString();
+        ChatRoomResponse chatRoomResponse = objectMapper.readValue(result, ChatRoomResponse.class);
+
+
+
+        Assertions.assertThat(chatRoomResponse.getToUserName()).isEqualTo("user1@naver.com");
+        Assertions.assertThat(chatRoomResponse.getLastMessage()).isEqualTo("chat3");
+
+
+    }
+}

--- a/src/test/java/com/api/farmingsoon/domain/chatting/ChattingIntegrationTest.java
+++ b/src/test/java/com/api/farmingsoon/domain/chatting/ChattingIntegrationTest.java
@@ -298,7 +298,7 @@ public class ChattingIntegrationTest {
         String result = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("result").toString();
         ChatListResponse chatListResponse = objectMapper.readValue(result, ChatListResponse.class);
 
-        Assertions.assertThat(chatListResponse.getChats().get(0).getSenderId()).isEqualTo("1");
+        Assertions.assertThat(chatListResponse.getChats().get(0).getSenderId()).isEqualTo(1);
         Assertions.assertThat(chatListResponse.getChats().get(0).getMessage()).isEqualTo("chat20");
         Assertions.assertThat(chatListResponse.getChats().get(7).getMessage()).isEqualTo("chat13");
 
@@ -324,7 +324,7 @@ public class ChattingIntegrationTest {
         String result = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("result").toString();
         ChatListResponse chatListResponse = objectMapper.readValue(result, ChatListResponse.class);
 
-        Assertions.assertThat(chatListResponse.getChats().get(0).getSenderId()).isEqualTo("2");
+        Assertions.assertThat(chatListResponse.getChats().get(0).getSenderId()).isEqualTo(2);
         Assertions.assertThat(chatListResponse.getChats().get(0).getMessage()).isEqualTo("chat20");
         Assertions.assertThat(chatListResponse.getChats().get(7).getMessage()).isEqualTo("chat13");
 

--- a/src/test/java/com/api/farmingsoon/domain/chatting/ChattingIntegrationTest.java
+++ b/src/test/java/com/api/farmingsoon/domain/chatting/ChattingIntegrationTest.java
@@ -92,7 +92,7 @@ public class ChattingIntegrationTest {
         for(int i = 1; i <= 2; i++){
             JoinRequest joinRequest = JoinRequest.builder()
                     .email("user" + i + "@naver.com")
-                    .nickname("user1")
+                    .nickname("user" + i)
                     .password("12345678")
                     .profileImg(profileImage).build();
 
@@ -129,7 +129,7 @@ public class ChattingIntegrationTest {
     @Test
     void createChatRoomByBuyer() throws Exception {
         //given
-        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of("user2@naver.com", 1L);
+        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of(2L, 1L);
 
         // when
         MvcResult mvcResult = mockMvc.perform(post("/api/chat-rooms")
@@ -156,7 +156,7 @@ public class ChattingIntegrationTest {
     @Test
     void createChatRoomBySeller() throws Exception {
         //given
-        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of("user2@naver.com", 1L);
+        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of(2L, 1L);
 
         // when
         MvcResult mvcResult = mockMvc.perform(post("/api/chat-rooms")
@@ -184,7 +184,7 @@ public class ChattingIntegrationTest {
     @Test
     void getChatRoomBySeller() throws Exception {
         //given
-        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of("user2@naver.com", 1L);
+        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of(2L, 1L);
         Long chatRoomId = chatRoomService.handleChatRoom(chatRoomCreateRequest);
         chatService.create(ChatMessageRequest.builder().chatRoomId(chatRoomId).message("chat1").build());
         chatService.create(ChatMessageRequest.builder().chatRoomId(chatRoomId).message("chat2").build());
@@ -199,7 +199,7 @@ public class ChattingIntegrationTest {
         String result = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("result").get(0).toString();
         ChatRoomResponse chatRoomResponse = objectMapper.readValue(result, ChatRoomResponse.class);
 
-        Assertions.assertThat(chatRoomResponse.getToUserName()).isEqualTo("user2@naver.com");
+        Assertions.assertThat(chatRoomResponse.getToUserName()).isEqualTo("user2");
         Assertions.assertThat(chatRoomResponse.getLastMessage()).isEqualTo("chat2");
 
 
@@ -210,7 +210,7 @@ public class ChattingIntegrationTest {
     @Test
     void getChatRoomByBuyer() throws Exception {
         //given
-        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of("user2@naver.com", 1L);
+        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of(2L, 1L);
         Long chatRoomId = chatRoomService.handleChatRoom(chatRoomCreateRequest);
         chatService.create(ChatMessageRequest.builder().chatRoomId(chatRoomId).message("chat1").build());
         chatService.create(ChatMessageRequest.builder().chatRoomId(chatRoomId).message("chat2").build());
@@ -226,7 +226,7 @@ public class ChattingIntegrationTest {
         String result = objectMapper.readTree(mvcResult.getResponse().getContentAsString()).get("result").get(0).toString();
         ChatRoomResponse chatRoomResponse = objectMapper.readValue(result, ChatRoomResponse.class);
 
-        Assertions.assertThat(chatRoomResponse.getToUserName()).isEqualTo("user1@naver.com");
+        Assertions.assertThat(chatRoomResponse.getToUserName()).isEqualTo("user1");
         Assertions.assertThat(chatRoomResponse.getLastMessage()).isEqualTo("chat3");
 
     }
@@ -236,7 +236,7 @@ public class ChattingIntegrationTest {
     @Test
     void getChatRoom1() throws Exception {
         //given
-        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of("user2@naver.com", 1L);
+        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of(2L, 1L);
         Long chatRoomId = chatRoomService.handleChatRoom(chatRoomCreateRequest);
 
         // when
@@ -257,7 +257,7 @@ public class ChattingIntegrationTest {
     @Test
     void getChatRoomDetail() throws Exception {
         //given
-        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of("user2@naver.com", 1L);
+        ChatRoomCreateRequest chatRoomCreateRequest = ChatRoomCreateRequest.of(2L, 1L);
         Long chatRoomId = chatRoomService.handleChatRoom(chatRoomCreateRequest);
         chatService.create(ChatMessageRequest.builder().chatRoomId(chatRoomId).message("chat1").build());
 
@@ -273,7 +273,6 @@ public class ChattingIntegrationTest {
 
         Assertions.assertThat(chatRoomDetailResponse.getItemId()).isEqualTo(1);
         Assertions.assertThat(chatRoomDetailResponse.getItemTitle()).isEqualTo("title");
-        Assertions.assertThat(chatRoomDetailResponse.getToUsername()).isEqualTo("user2@naver.com");
 
     }
 }

--- a/src/test/java/com/api/farmingsoon/domain/item/ItemIntegrationTest.java
+++ b/src/test/java/com/api/farmingsoon/domain/item/ItemIntegrationTest.java
@@ -1,10 +1,8 @@
-package com.api.farmingsoon.domain.item.controller;
+package com.api.farmingsoon.domain.item;
 
 import com.api.farmingsoon.common.clean.DatabaseCleanup;
 import com.api.farmingsoon.common.util.TimeUtils;
 import com.api.farmingsoon.domain.bid.dto.BidRequest;
-import com.api.farmingsoon.domain.bid.model.Bid;
-import com.api.farmingsoon.domain.bid.model.BidResult;
 import com.api.farmingsoon.domain.bid.service.BidService;
 import com.api.farmingsoon.domain.item.domain.Item;
 import com.api.farmingsoon.domain.item.domain.ItemStatus;
@@ -54,7 +52,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-class ItemControllerTest {
+class ItemIntegrationTest {
 
     @Autowired
     private MemberService memberService;

--- a/src/test/java/com/api/farmingsoon/domain/like/LikeableItemIntegrationTest.java
+++ b/src/test/java/com/api/farmingsoon/domain/like/LikeableItemIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.api.farmingsoon.domain.like.controller;
+package com.api.farmingsoon.domain.like;
 
 import com.api.farmingsoon.common.clean.DatabaseCleanup;
 import com.api.farmingsoon.common.util.TimeUtils;

--- a/src/test/java/com/api/farmingsoon/domain/member/MemberIntegrationTest.java
+++ b/src/test/java/com/api/farmingsoon/domain/member/MemberIntegrationTest.java
@@ -1,4 +1,4 @@
-package com.api.farmingsoon.domain.member.controller;
+package com.api.farmingsoon.domain.member;
 
 import com.api.farmingsoon.common.clean.DatabaseCleanup;
 import com.api.farmingsoon.domain.member.dto.JoinRequest;
@@ -6,15 +6,12 @@ import com.api.farmingsoon.domain.member.dto.LoginRequest;
 import com.api.farmingsoon.domain.member.model.Member;
 import com.api.farmingsoon.domain.member.service.MemberService;
 import com.api.farmingsoon.util.TestImageUtils;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -22,18 +19,16 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.junit.jupiter.api.Assertions.*;
+
 import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.ResultActions;
 
 import java.io.IOException;
 
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
-class MemberControllerTest {
+class MemberIntegrationTest {
     @Autowired
     private ObjectMapper objectMapper;
     @Autowired


### PR DESCRIPTION
## 💡 관련 이슈

- #76 

## ✅ 작업 상세 내용

- [ ] 채팅방, 채팅 테스트 자동화
- [ ] 채팅 내역이 없는 채팅방은 조회되지 않도록 수정
- [ ] 채팅 내역이 없을 때 NPE뜨는 버그 수정
- [ ] api url수정
- [ ] 채팅방 핸들링을 위해 username을 받던 부분 id사용하도록 변경
- [ ] username으로 email노출하는 부분 nickname으로 변경

## ⭐ 특이사항

## 📃 참고할만한 자료
