### PR TITLE
메시징 권한 체킹 버그 수정

### DIFF
--- a/src/main/java/com/api/farmingsoon/common/interceptor/StompInterceptor.java
+++ b/src/main/java/com/api/farmingsoon/common/interceptor/StompInterceptor.java
@@ -1,0 +1,44 @@
+package com.api.farmingsoon.common.interceptor;
+
+import com.api.farmingsoon.common.exception.ErrorCode;
+import com.api.farmingsoon.common.exception.custom_exception.ForbiddenException;
+import com.api.farmingsoon.common.security.jwt.JwtProvider;
+import com.api.farmingsoon.common.util.JwtUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompInterceptor implements ChannelInterceptor {
+    private final JwtProvider jwtProvider;
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        log.info("command : " + accessor.getCommand() + " token : " + accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION));
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand()))
+            validateToken(accessor);
+
+        return message;
+    }
+
+    private void validateToken(StompHeaderAccessor accessor) {
+        String accessToken = JwtUtils.extractBearerToken(accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION));
+
+        if (accessToken == null)
+            throw new ForbiddenException(ErrorCode.NOT_LOGIN);
+
+        jwtProvider.validateAccessToken(accessToken);
+
+    }
+}

--- a/src/main/java/com/api/farmingsoon/common/websocket/WebSocketConfig.java
+++ b/src/main/java/com/api/farmingsoon/common/websocket/WebSocketConfig.java
@@ -1,6 +1,9 @@
 package com.api.farmingsoon.common.websocket;
 
+import com.api.farmingsoon.common.interceptor.StompInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,7 +11,9 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    private final StompInterceptor stompInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -21,5 +26,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws")
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
+    }
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompInterceptor);
     }
 }

--- a/src/main/java/com/api/farmingsoon/domain/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/com/api/farmingsoon/domain/chat/dto/ChatMessageRequest.java
@@ -7,10 +7,12 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessageRequest {
     private Long chatRoomId;
+    private Long senderId;
     private String message;
 
     @Builder
-    public ChatMessageRequest(Long chatRoomId, String message) {
+    public ChatMessageRequest(Long chatRoomId,Long senderId, String message) {
+        this.senderId = senderId;
         this.chatRoomId = chatRoomId;
         this.message = message;
     }

--- a/src/main/java/com/api/farmingsoon/domain/chat/service/ChatService.java
+++ b/src/main/java/com/api/farmingsoon/domain/chat/service/ChatService.java
@@ -9,6 +9,7 @@ import com.api.farmingsoon.domain.chat.repository.ChatRepository;
 import com.api.farmingsoon.domain.chatroom.model.ChatRoom;
 import com.api.farmingsoon.domain.chatroom.service.ChatRoomService;
 import com.api.farmingsoon.domain.member.model.Member;
+import com.api.farmingsoon.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -23,12 +24,12 @@ public class ChatService {
 
     private final ChatRepository chatRepository;
     private final ChatRoomService chatRoomService;
-    private final AuthenticationUtils authenticationUtils;
+    private final MemberService memberService;
 
     @Transactional
     public ChatResponse create(ChatMessageRequest chatMessageRequest) {
         ChatRoom chatRoom = chatRoomService.getChatRoom(chatMessageRequest.getChatRoomId());
-        Member sender = authenticationUtils.getAuthenticationMember();
+        Member sender = memberService.getMemberById(chatMessageRequest.getSenderId());
         Chat chat = chatRepository.save(Chat.of(chatMessageRequest.getMessage(), sender, chatRoom));
 
         return ChatResponse.of(chat);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,10 @@ spring:
     redis:
       host: localhost
       port: 6379
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 #  sql:
 #    init:
 #      mode: always


### PR DESCRIPTION
## 💡 관련 이슈

- #88 

## ✅ 작업 상세 내용

- [ ] HTTP 요청에 대한 Interceptor는 websocket요청에 대해 처리 불가능함에 의해 인증 과정이 누락
-> 토큰을 담았음에도 인증 객체가 NULL인 문제 발생
- [ ] 메시지 전송 직전을 인터셉트하는 ChannelInterceptor에서 인증 진행
-> 이에 따른 인증 객체를 통한 sender조회 로직을 변경 
- [ ] ChatRequest senderId 추가
- [ ] 이미지 사이즈 조정(10MB )

## ⭐ 특이사항
- ChannelInterceptor에서 command가 CONNECT일 때만 JWT검증 진행

## 📃 참고할만한 자료

This closed #88 