### PR TITLE
도메인 변경에 따른 SameSite전략 변경

### DIFF
--- a/src/main/java/com/api/farmingsoon/common/util/CookieUtils.java
+++ b/src/main/java/com/api/farmingsoon/common/util/CookieUtils.java
@@ -39,7 +39,7 @@ public class CookieUtils {
         String randomCookieValue = UUID.randomUUID().toString();
         ResponseCookie cookie = ResponseCookie.from("viewCountCookie", randomCookieValue)
                 .path("/")
-                .sameSite("None")
+                .sameSite("Strict")
                 .httpOnly(true)
                 .secure(true)
                 .maxAge(TimeUtils.getRemainingTimeUntilMidnight())


### PR DESCRIPTION
## 💡 관련 이슈

- #94 

## ✅ 작업 상세 내용

- [ ] 클라이언트 서버와 api서버의 도메인을 일치시켰기에 samesite전략을 수정합니다.
- [ ] 같은 도메인 내에서만 쿠키 통신이 가능함을 보장하는 Strict전략을 이용합니다.

## ⭐ 특이사항

## 📃 참고할만한 자료

This closed #94 
