### PR TITLE
토큰 저장 방식 변경에 따른 사이드 이펙트 처리

### DIFF
--- a/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
@@ -6,6 +6,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
+    // 303
+    ALREADY_LOGIN("이미 로그인 상태입니다.", HttpStatus.SEE_OTHER),
+
     // 400
     EMPTY_REFRESH_TOKEN("RefreshToken이 필요합니다.", HttpStatus.BAD_REQUEST),
     EMPTY_EMAIL("이메일이 필요합니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/api/farmingsoon/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/api/farmingsoon/common/interceptor/AuthenticationInterceptor.java
@@ -1,5 +1,7 @@
 package com.api.farmingsoon.common.interceptor;
 
+import com.api.farmingsoon.common.exception.CustomException;
+import com.api.farmingsoon.common.exception.ErrorCode;
 import com.api.farmingsoon.common.security.jwt.JwtProvider;
 import com.api.farmingsoon.common.util.CookieUtils;
 import com.api.farmingsoon.common.util.JwtUtils;
@@ -30,10 +32,15 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         log.info(refreshToken);
 
         if (accessToken != null) { // 토큰 재발급의 요청이 아니면서 accessToken이 존재할 때
-
-            if (jwtProvider.validateAccessToken(accessToken)) { // 토큰이 유효한 경우 and 로그인 상태
-                Authentication authentication = jwtProvider.getAuthenticationByAccessToken(accessToken);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+            if(jwtProvider.validateAccessToken(accessToken)){
+                if(request.getRequestURI().equals("/api/members/login")) // 토큰이 유효한데 로그인 요청을 한다면 -> 이미 로그인된 사용자 예외 처리
+                {
+                    throw new CustomException(ErrorCode.ALREADY_LOGIN);
+                }
+                else{ // 로그인 요청이 아니면서 토큰이 유효한 경우 인증객체 세팅 -> 이후 로직 진행
+                    Authentication authentication = jwtProvider.getAuthenticationByAccessToken(accessToken);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
         }
 

--- a/src/main/java/com/api/farmingsoon/common/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/com/api/farmingsoon/common/interceptor/AuthenticationInterceptor.java
@@ -24,6 +24,10 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         log.info(request.getHeader("Origin"));
         log.info("Authentication Interceptor : " + request.getRequestURI());
         String accessToken = CookieUtils.getAccessTokenCookieValue(request);
+        String refreshToken = CookieUtils.getRefreshTokenCookieValue(request);
+
+        log.info(accessToken);
+        log.info(refreshToken);
 
         if (accessToken != null) { // 토큰 재발급의 요청이 아니면서 accessToken이 존재할 때
 

--- a/src/main/java/com/api/farmingsoon/common/interceptor/StompInterceptor.java
+++ b/src/main/java/com/api/farmingsoon/common/interceptor/StompInterceptor.java
@@ -3,6 +3,7 @@ package com.api.farmingsoon.common.interceptor;
 import com.api.farmingsoon.common.exception.ErrorCode;
 import com.api.farmingsoon.common.exception.custom_exception.ForbiddenException;
 import com.api.farmingsoon.common.security.jwt.JwtProvider;
+import com.api.farmingsoon.common.util.CookieUtils;
 import com.api.farmingsoon.common.util.JwtUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +25,7 @@ public class StompInterceptor implements ChannelInterceptor {
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
-        log.info("command : " + accessor.getCommand() + " token : " + accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION));
+        log.info("command : " + accessor.getCommand());
 
 /*
         if (StompCommand.CONNECT.equals(accessor.getCommand()))

--- a/src/main/java/com/api/farmingsoon/common/util/CookieUtils.java
+++ b/src/main/java/com/api/farmingsoon/common/util/CookieUtils.java
@@ -62,11 +62,10 @@ public class CookieUtils {
     private static String createAndSetViewCountCookie(HttpServletResponse response) {
         String randomCookieValue = UUID.randomUUID().toString();
         ResponseCookie cookie = ResponseCookie.from("viewCountCookie", randomCookieValue)
-                .path("/")
+                .path("/api/items/")
                 .sameSite("Strict")
                 .domain("farmingsoon.site")
                 .httpOnly(true)
-                .domain("farmingsoon.site")
                 .secure(true)
                 .maxAge(TimeUtils.getRemainingTimeUntilMidnight())
                 .build();
@@ -90,7 +89,7 @@ public class CookieUtils {
 
     private static void createAndSetRefreshTokenCookie(String refreshToken, Long refreshExpirationTime, HttpServletResponse response) {
         ResponseCookie cookie = ResponseCookie.from("RefreshToken", refreshToken)
-                .path("/")
+                .path("/api/members/refresh-token/")
                 .sameSite("Strict")
                 .domain("farmingsoon.site")
                 .httpOnly(true)

--- a/src/main/java/com/api/farmingsoon/common/web/WebConfig.java
+++ b/src/main/java/com/api/farmingsoon/common/web/WebConfig.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private  final AuthenticationInterceptor authenticationInterceptor;
-    private final List<String> excludePointList = Arrays.asList();
+    private final List<String> excludePointList = Arrays.asList("/api/members/refresh-token/**");
 
     private final List<String> addEndPointList = Arrays.asList("/api/**");
     /**

--- a/src/main/java/com/api/farmingsoon/common/websocket/WebSocketConfig.java
+++ b/src/main/java/com/api/farmingsoon/common/websocket/WebSocketConfig.java
@@ -24,7 +24,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("http://localhost:3000", "https://farmingsoon.site", "https://farmingsoon.vercel.app")
+                .setAllowedOriginPatterns("http://localhost:3000", "https://farmingsoon.site")
                 .withSockJS();
     }
     @Override

--- a/src/main/java/com/api/farmingsoon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,6 +21,7 @@ import java.io.IOException;
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
+@Slf4j
 public class MemberController {
 
     private final MemberService memberService;
@@ -40,6 +42,7 @@ public class MemberController {
     @PostMapping("/refresh-token/logout")
     public Response<Void> logoutMember(HttpServletRequest request) {
         String refreshToken = JwtUtils.getRefreshToken(request);
+        log.info(refreshToken);
         memberService.logout(refreshToken);
         return Response.success(HttpStatus.OK, "로그아웃 처리 되었습니다.");
     }
@@ -48,7 +51,7 @@ public class MemberController {
     public Response<Void> rotateToken(HttpServletRequest request, HttpServletResponse response){
         String refreshToken = JwtUtils.getRefreshToken(request);
         memberService.rotateToken(refreshToken, response);
-
+        log.info(refreshToken);
         return Response.success(HttpStatus.OK, "토큰이 재발급 되었습니다.");
     }
 

--- a/src/main/java/com/api/farmingsoon/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/farmingsoon/domain/member/controller/MemberController.java
@@ -37,14 +37,14 @@ public class MemberController {
     }
 
 
-    @PostMapping("/logout")
+    @PostMapping("/refresh-token/logout")
     public Response<Void> logoutMember(HttpServletRequest request) {
         String refreshToken = JwtUtils.getRefreshToken(request);
         memberService.logout(refreshToken);
         return Response.success(HttpStatus.OK, "로그아웃 처리 되었습니다.");
     }
 
-    @GetMapping("/rotate")
+    @GetMapping("/refresh-token/rotate")
     public Response<Void> rotateToken(HttpServletRequest request, HttpServletResponse response){
         String refreshToken = JwtUtils.getRefreshToken(request);
         memberService.rotateToken(refreshToken, response);

--- a/src/test/java/com/api/farmingsoon/domain/member/MemberIntegrationTest.java
+++ b/src/test/java/com/api/farmingsoon/domain/member/MemberIntegrationTest.java
@@ -134,7 +134,7 @@ class MemberIntegrationTest {
                 .findFirst();
 
 
-        MvcResult mvcResult2 = mockMvc.perform(get("/api/members/rotate")
+        MvcResult mvcResult2 = mockMvc.perform(get("/api/members/refresh-token/rotate")
                         .cookie(refreshTokenCookie.get())
                 )
                 .andDo(print())
@@ -177,14 +177,14 @@ class MemberIntegrationTest {
                 .filter(cookie -> cookie.getName().equals("RefreshToken"))
                 .findFirst();
 
-        MvcResult mvcResult2 = mockMvc.perform(post("/api/members/logout")
+        MvcResult mvcResult2 = mockMvc.perform(post("/api/members/refresh-token/logout")
                         .cookie(refreshTokenCookie.get()))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn();
 
 
-        MvcResult mvcResult3 = mockMvc.perform(get("/api/members/rotate")
+        MvcResult mvcResult3 = mockMvc.perform(get("/api/members/refresh-token/rotate")
                         .cookie(refreshTokenCookie.get()))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())


### PR DESCRIPTION
## 💡 관련 이슈

- #106 

## ✅ 작업 상세 내용

- [ ] RT 사용하는 api url 변경
- [ ] 쿠키 사용하는 api에 대해서만 전송하도록 변경
- [ ] refreshToken이 필요한 요청에 대해서는 인터셉터 배제
- [ ] StompInterceptor 토큰 확인 제거
- [ ] 로그인된 사용자 예외처리

## ⭐ 특이사항

## 📃 참고할만한 자료

This closed #106 