### PR TITLE
채팅 읽음 처리 Bulk Update 도입

### DIFF
--- a/src/main/java/com/api/farmingsoon/domain/chat/repository/ChatRepositoryCustom.java
+++ b/src/main/java/com/api/farmingsoon/domain/chat/repository/ChatRepositoryCustom.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface ChatRepositoryCustom {
     List<Chat> findMyNotReadChatList(ChatRoom chatroom, Member member);
+    void readAllMyNotReadChatList(ChatRoom chatroom, Member member);
 }

--- a/src/main/java/com/api/farmingsoon/domain/chat/repository/ChatRepositoryCustomImpl.java
+++ b/src/main/java/com/api/farmingsoon/domain/chat/repository/ChatRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.api.farmingsoon.domain.chat.model.QChat;
 import com.api.farmingsoon.domain.chatroom.model.ChatRoom;
 import com.api.farmingsoon.domain.member.model.Member;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,6 +22,7 @@ import static com.api.farmingsoon.domain.member.model.QMember.member;
 public class ChatRepositoryCustomImpl implements ChatRepositoryCustom{
 
     private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
 
     @Override
     public List<Chat> findMyNotReadChatList(ChatRoom chatRoom, Member member) {
@@ -36,7 +38,8 @@ public class ChatRepositoryCustomImpl implements ChatRepositoryCustom{
                 .where(chat.chatRoom.eq(chatroom), chat.isRead.isFalse(), chat.sender.ne(member))
                 .set(chat.isRead, true)
                 .execute();
-
+        em.flush();
+        em.clear();
 
     }
 }

--- a/src/main/java/com/api/farmingsoon/domain/chat/repository/ChatRepositoryCustomImpl.java
+++ b/src/main/java/com/api/farmingsoon/domain/chat/repository/ChatRepositoryCustomImpl.java
@@ -29,4 +29,14 @@ public class ChatRepositoryCustomImpl implements ChatRepositoryCustom{
                         .fetch();
 
     }
+
+    @Override
+    public void readAllMyNotReadChatList(ChatRoom chatroom, Member member) {
+        queryFactory.update(chat)
+                .where(chat.chatRoom.eq(chatroom), chat.isRead.isFalse(), chat.sender.ne(member))
+                .set(chat.isRead, true)
+                .execute();
+
+
+    }
 }

--- a/src/main/java/com/api/farmingsoon/domain/chat/service/ChatService.java
+++ b/src/main/java/com/api/farmingsoon/domain/chat/service/ChatService.java
@@ -69,7 +69,11 @@ public class ChatService {
     public void readAllMyNotReadChatList(Long chatRoomId, Long memberId) {
         ChatRoom chatRoom = chatRoomService.getChatRoom(chatRoomId);
         Member member = memberService.getMemberById(memberId);
+        chatRepository.readAllMyNotReadChatList(chatRoom, member);
+
+        /*
         List<Chat> myNotReadChatList = chatRepository.findMyNotReadChatList(chatRoom, member);
         myNotReadChatList.forEach(Chat::read);
+        */
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈

- #129 

## ✅ 작업 상세 내용

- [ ] 채팅방 접속 시 읽지 않은 메시지에 대해 전체 읽음 처리하는 과정에서 개별 쿼리가 나가는 문제 해결을 위해 Bulk Update도입

## ⭐ 특이사항

## 📃 참고할만한 자료
