### PR TITLE
상품 조회 likeStatus버그 수정

### DIFF
--- a/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
+++ b/src/main/java/com/api/farmingsoon/common/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     FORBIDDEN_DELETE("삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
     FORBIDDEN_UPDATE("수정 권한이 없습니다.", HttpStatus.FORBIDDEN),
     EMPTY_AUTHORITY("권한 정보가 비어있습니다.", HttpStatus.FORBIDDEN),
+    OWN_ITEM("자신의 게시글에는 좋아요를 누를 수 없습니다.", HttpStatus.FORBIDDEN),
 
     // 404
     NOT_FOUND_MEMBER("회원이 존재하지 않습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/api/farmingsoon/domain/item/dto/ItemDetailResponse.java
+++ b/src/main/java/com/api/farmingsoon/domain/item/dto/ItemDetailResponse.java
@@ -57,7 +57,7 @@ public class ItemDetailResponse {
                 .likeStatus // 조회자 세션이 존재할 경우에만 비교를 한다.
                     (
                         viewer.isPresent() ?
-                        item.getLikeableItemList().stream().map(LikeableItem::getMember).toList().contains(viewer) : false
+                        item.getLikeableItemList().stream().map(LikeableItem::getMember).toList().contains(viewer.get()) : false
                     )
                 .build();
     }

--- a/src/main/java/com/api/farmingsoon/domain/item/dto/ItemListResponse.java
+++ b/src/main/java/com/api/farmingsoon/domain/item/dto/ItemListResponse.java
@@ -68,7 +68,6 @@ public class ItemListResponse {
         }
 
         private static ItemResponse of(Item item, Optional<Member> viewer) {
-
             return ItemResponse.builder()
                     .itemId(item.getId())
                     .title(item.getTitle())
@@ -84,8 +83,7 @@ public class ItemListResponse {
                     .thumbnailImgUrl(item.getThumbnailImageUrl())
                     .likeStatus // 조회자 세션이 존재할 경우에만 비교를 한다.
                             (
-                                    viewer.isPresent() ?
-                                            item.getLikeableItemList().stream().map(LikeableItem::getMember).toList().contains(viewer) : false
+                                viewer.isPresent() ? item.getLikeableItemList().stream().map(LikeableItem::getMember).toList().contains(viewer.get()) : false
                             )
                     .build();
         }

--- a/src/main/java/com/api/farmingsoon/domain/like/service/LikeableItemService.java
+++ b/src/main/java/com/api/farmingsoon/domain/like/service/LikeableItemService.java
@@ -2,6 +2,7 @@ package com.api.farmingsoon.domain.like.service;
 
 import com.api.farmingsoon.common.exception.ErrorCode;
 import com.api.farmingsoon.common.exception.custom_exception.DuplicateException;
+import com.api.farmingsoon.common.exception.custom_exception.ForbiddenException;
 import com.api.farmingsoon.common.exception.custom_exception.NotFoundException;
 import com.api.farmingsoon.common.util.AuthenticationUtils;
 import com.api.farmingsoon.domain.item.domain.Item;
@@ -32,6 +33,9 @@ public class LikeableItemService {
     public void like(Long itemId) {
         Member member = authenticationUtils.getAuthenticationMember();
         Item item = itemRepository.findById(itemId).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ITEM));
+
+        if(item.getMember() == member)
+            throw new ForbiddenException(ErrorCode.OWN_ITEM);
 
         // 해당 상품에 이미 좋아요를 누른 경우 예외 처리
         likeableItemRepository.findByMemberAndItem(member, item).ifPresent(it -> {


### PR DESCRIPTION
## 💡 관련 이슈

- #143 

## ✅ 작업 상세 내용

- [ ] 관심상품을 누른 회원과 조회자를 비교하는 과정에서 Optional 그대로의 객체와 비교했기 때문에 제대로 처리가 안되던 부분 수정
- [ ] 자신의 게시물에는 좋아요 누를수 없음(예외처리)
- [ ] 테스트 작성

## ⭐ 특이사항

## 📃 참고할만한 자료
